### PR TITLE
Data types support: Handle NUMERIC field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2
+
+- **Data types support**: Handle NUMERIC data type
+
 ## 0.1.1
 
 - **Autocomplete**: Fixed the broken dataset/table suggestions if project id or dataset id contains a keyword defined in Monaco's default SQL language definition.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Google BigQuery datasource for Grafana",
   "scripts": {
     "dev": "grafana-toolkit plugin:dev",

--- a/pkg/bigquery/driver/rows.go
+++ b/pkg/bigquery/driver/rows.go
@@ -68,7 +68,7 @@ func (r *rows) bigqueryTypeOf(columnType *string) (reflect.Type, error) {
 	switch *columnType {
 	case "TINYINT", "SMALLINT", "INT", "INTEGER", "INT64":
 		return reflect.TypeOf(int64(0)), nil
-	case "FLOAT", "FLOAT64":
+	case "FLOAT", "FLOAT64", "NUMERIC":
 		return reflect.TypeOf(float64(0)), nil
 	case "STRING":
 		return reflect.TypeOf(""), nil

--- a/pkg/bigquery/driver/utils.go
+++ b/pkg/bigquery/driver/utils.go
@@ -3,11 +3,11 @@ package driver
 import (
 	"database/sql/driver"
 	"fmt"
+	"math/big"
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
 )
-
 
 // Converts an arbitrary bigquery.Value to a driver.Value
 func ConvertColumnValue(v bigquery.Value, fieldSchema *bigquery.FieldSchema) (driver.Value, error) {
@@ -43,6 +43,9 @@ func ConvertColumnValue(v bigquery.Value, fieldSchema *bigquery.FieldSchema) (dr
 			return nil, err
 		}
 		return res, nil
+	case "NUMERIC":
+		conv, _ := v.(*big.Rat).Float64()
+		return conv, nil
 	default:
 		return v, nil
 	}

--- a/pkg/bigquery/driver/utils_test.go
+++ b/pkg/bigquery/driver/utils_test.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"cloud.google.com/go/bigquery"
@@ -12,6 +13,8 @@ import (
 )
 
 func Test_ConvertColumnValue(t *testing.T) {
+	bigRatFromString, _ := new(big.Rat).SetString("11.111111111")
+
 	tests := []struct {
 		name          string
 		columnType    string
@@ -76,6 +79,30 @@ func Test_ConvertColumnValue(t *testing.T) {
 			schema:        &bigquery.FieldSchema{Type: "FLOAT64"},
 			expectedType:  "float64",
 			expectedValue: "1.99999",
+		},
+		{
+			name:          "numeric type NUMERIC",
+			value:         bigquery.Value((&big.Rat{}).SetInt64(2)),
+			columnType:    "NUMERIC",
+			schema:        &bigquery.FieldSchema{Type: "NUMERIC"},
+			expectedType:  "float64",
+			expectedValue: "2",
+		},
+		{
+			name:          "numeric type NUMERIC",
+			value:         bigquery.Value((&big.Rat{}).SetFloat64(1.99999)),
+			columnType:    "NUMERIC",
+			schema:        &bigquery.FieldSchema{Type: "NUMERIC"},
+			expectedType:  "float64",
+			expectedValue: "1.99999",
+		},
+		{
+			name:          "numeric type NUMERIC",
+			value:         bigquery.Value(bigRatFromString),
+			columnType:    "NUMERIC",
+			schema:        &bigquery.FieldSchema{Type: "NUMERIC"},
+			expectedType:  "float64",
+			expectedValue: "11.111111111",
 		},
 		{
 			name:          "DATE",


### PR DESCRIPTION
Add support for [NUMERIC](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric_types) columns