### PR TITLE
Bummp experimental to -15

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@grafana/data": "canary",
-    "@grafana/experimental": "0.0.2-canary.14",
+    "@grafana/experimental": "0.0.2-canary.15",
     "@grafana/runtime": "canary",
     "@grafana/ui": "canary",
     "brace": "^0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1292,10 +1292,10 @@
     prettier "2.2.1"
     typescript "4.3.4"
 
-"@grafana/experimental@0.0.2-canary.14":
-  version "0.0.2-canary.14"
-  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.14.tgz#376bcf69bdbea1616b76c426656ede0c7dacd413"
-  integrity sha512-iytvIHrwiSHU6VhmtXe8TIWy5Jxq2AcQ2bOBrCnTYSs/ngTsprrNrnsdw4KzRzi12edZlvnY/Xcvpdl4dNYgOw==
+"@grafana/experimental@0.0.2-canary.15":
+  version "0.0.2-canary.15"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.15.tgz#5cf9ab11512973c301c4f95a444d476d88cf0959"
+  integrity sha512-52l9J9EU558Mt55TE2OYofafjF3rzhZE1eBJIpmE3JUSZe+ANptxWbbu+ZD2XMmIaxeoZ1W0r7kGtvAFLZug8w==
   dependencies:
     "@types/uuid" "^8.3.3"
     uuid "^8.3.2"


### PR DESCRIPTION
To allow `yarn watch` 

This brings data source in Grafana <8 - we need to figure out a way for handling that soon.