### PR TITLE
Query validation: Interpolate template variables and macros before performing dry run

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/grafana/grafana-plugin-sdk-go v0.121.0
-	github.com/grafana/sqlds/v2 v2.3.2
+	github.com/grafana/sqlds/v2 v2.3.4
 	github.com/hashicorp/go-hclog v0.16.2 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
 	github.com/hashicorp/yamux v0.0.0-20210826001029-26ff87cf9493 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
-github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
@@ -254,12 +252,10 @@ github.com/grafana/grafana-google-sdk-go v0.0.0-20211104130251-b190293eaf58 h1:2
 github.com/grafana/grafana-google-sdk-go v0.0.0-20211104130251-b190293eaf58/go.mod h1:Vo2TKWfDVmNTELBUM+3lkrZvFtBws0qSZdXhQxRdJrE=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
-github.com/grafana/grafana-plugin-sdk-go v0.119.0 h1:FRmfzdjlVWIxDLQvcKpEcf1kmdLbk662YpmXrqg+GAM=
-github.com/grafana/grafana-plugin-sdk-go v0.119.0/go.mod h1:Mhy+5mC6rSqEhnzop1wEh//n/fgkzNK5pRgg3DfCp4g=
 github.com/grafana/grafana-plugin-sdk-go v0.121.0 h1:4+dXoezL9L40iu7ym4u7ZJ4OE57NaVc4WSHlbxtCtGM=
 github.com/grafana/grafana-plugin-sdk-go v0.121.0/go.mod h1:Mhy+5mC6rSqEhnzop1wEh//n/fgkzNK5pRgg3DfCp4g=
-github.com/grafana/sqlds/v2 v2.3.2 h1:HiMPTn/g4CXPXjWYLc22KwKSK5yR2DyG0wr95M7giZM=
-github.com/grafana/sqlds/v2 v2.3.2/go.mod h1:34uyqPBWsEvg4V/xxh6V4uIqwu1qLfOfsmScll/ukrk=
+github.com/grafana/sqlds/v2 v2.3.4 h1:Pp285fAXrtO5AijZKoNdNc0Xs1LtTEbqJ43uXhHrtb8=
+github.com/grafana/sqlds/v2 v2.3.4/go.mod h1:c6ibxnxRVGxV/0YkEgvy7QpQH/lyifFyV7K/14xvdIs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=

--- a/pkg/bigquery/datasource.go
+++ b/pkg/bigquery/datasource.go
@@ -247,9 +247,9 @@ func (s *BigQueryDatasource) Columns(ctx context.Context, options sqlds.Options)
 }
 
 type ValidateQueryArgs struct {
-	Project  string `json:"project"`
-	Location string `json:"location"`
-	Query    string `json:"query"`
+	Project  string      `json:"project"`
+	Location string      `json:"location"`
+	Query    sqlds.Query `json:"query"`
 }
 
 func (s *BigQueryDatasource) ValidateQuery(ctx context.Context, options ValidateQueryArgs) (*api.ValidateQueryResponse, error) {
@@ -259,7 +259,12 @@ func (s *BigQueryDatasource) ValidateQuery(ctx context.Context, options Validate
 		return nil, errors.WithMessage(err, "Failed to retrieve BigQuery API client")
 	}
 
-	return apiClient.ValidateQuery(ctx, options.Query), nil
+	query, err := sqlds.Interpolate(s, &options.Query)
+	if err != nil {
+		return nil, errors.WithMessage(err, "Could not apply macros")
+	}
+
+	return apiClient.ValidateQuery(ctx, query), nil
 }
 
 type TableSchemaArgs struct {

--- a/src/components/query-editor-raw/QueryValidator.tsx
+++ b/src/components/query-editor-raw/QueryValidator.tsx
@@ -48,7 +48,8 @@ export function QueryValidator({ apiClient, query, onValidate }: QueryValidatorP
       if (!q.location || q.rawSql.trim() === '') {
         return null;
       }
-      return await apiClient.validateQuery(q.location, q.rawSql);
+
+      return await apiClient.validateQuery(q);
     },
     [apiClient]
   );


### PR DESCRIPTION
Blocked by https://github.com/grafana/sqlds/pull/59

Current query validation is performed against not interpolated SQL resulting in wrong validation results. This PR makes sure template variables and macros are interpolated before perfoming dry run.

