### PR TITLE
Code editor: Improve WHERE clause suggestions and query validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.9
+
+- **Autocomplete**: Add suggestions for columns in WHERE clause.
+- **Query validation**: Actively run query validation on query change rather than on blur.
+- **Code editor**: Run query when CTRL/CMD+Return is pressed.
+
 ## 0.1.8
 
 - **Autocomplete**: Improve tables suggestions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Google BigQuery datasource for Grafana",
   "scripts": {
     "dev": "grafana-toolkit plugin:dev",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@emotion/css": "11.1.3",
     "@grafana/data": "canary",
-    "@grafana/experimental": "0.0.2-canary.20",
+    "@grafana/experimental": "0.0.2-canary.21",
     "@grafana/runtime": "canary",
     "@grafana/ui": "canary",
     "brace": "^0.10.0",

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -27,6 +27,7 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
     order: !!queryWithDefaults.sql.orderBy?.property.name,
     preview: true,
   });
+  const [queryToValidate, setQueryToValidate] = useState(queryWithDefaults);
 
   useEffect(() => {
     return () => {
@@ -43,9 +44,13 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
     [onRunQuery]
   );
 
-  const onQueryChange = (q: BigQueryQueryNG) => {
+  const onQueryChange = (q: BigQueryQueryNG, process = true) => {
+    setQueryToValidate(q as any);
     onChange(q);
-    processQuery(q);
+
+    if (process) {
+      processQuery(q);
+    }
   };
 
   if (apiLoading || apiError || !apiClient) {
@@ -77,8 +82,8 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
 
       {queryWithDefaults.editorMode === EditorMode.Code && (
         <>
-          <RawEditor apiClient={apiClient} query={queryWithDefaults} onChange={onChange} onRunQuery={onRunQuery} />
-          <QueryValidator apiClient={apiClient} query={queryWithDefaults} onValidate={setIsQueryRunnable} />
+          <RawEditor apiClient={apiClient} query={queryWithDefaults} onChange={onQueryChange} onRunQuery={onRunQuery} />
+          <QueryValidator apiClient={apiClient} query={queryToValidate} onValidate={setIsQueryRunnable} />
         </>
       )}
     </>

--- a/src/components/query-editor-raw/QueryEditorRaw.tsx
+++ b/src/components/query-editor-raw/QueryEditorRaw.tsx
@@ -9,8 +9,7 @@ type Props = {
   getTables: (d?: string) => Promise<TableDefinition[]>;
   getColumns: (t: string) => Promise<ColumnDefinition[]>;
   getTableSchema: (l: string, d: string, t: string) => Promise<TableSchema | null>;
-  onChange: (value: BigQueryQueryNG) => void;
-  onRunQuery: () => void;
+  onChange: (value: BigQueryQueryNG, processQuery: boolean) => void;
 };
 
 export function QueryEditorRaw({
@@ -18,7 +17,6 @@ export function QueryEditorRaw({
   getTables: apiGetTables,
   getTableSchema: apiGetTableSchema,
   onChange,
-  onRunQuery,
   query,
 }: Props) {
   const getColumns = useRef<Props['getColumns']>(apiGetColumns);
@@ -35,18 +33,23 @@ export function QueryEditorRaw({
   }, [apiGetColumns, apiGetTables]);
 
   const onRawQueryChange = useCallback(
-    (rawSql: string) => {
+    (processQuery: boolean) => (rawSql: string) => {
       const newQuery = {
         ...query,
         rawQuery: true,
         rawSql,
       };
-      onChange(newQuery);
+      onChange(newQuery, processQuery);
     },
     [onChange, query]
   );
 
   return (
-    <SQLEditor query={query.rawSql} onChange={onRawQueryChange} language={{ id: 'bigquery', completionProvider }} />
+    <SQLEditor
+      query={query.rawSql}
+      onBlur={onRawQueryChange(true)}
+      onChange={onRawQueryChange(false)}
+      language={{ id: 'bigquery', completionProvider }}
+    />
   );
 }

--- a/src/components/query-editor-raw/RawEditor.tsx
+++ b/src/components/query-editor-raw/RawEditor.tsx
@@ -1,10 +1,11 @@
 import { QueryEditorRaw } from './QueryEditorRaw';
 import React, { useCallback } from 'react';
 import { getColumnInfoFromSchema } from 'utils/getColumnInfoFromSchema';
-import { QueryEditorProps } from 'types';
+import { BigQueryQueryNG, QueryEditorProps } from 'types';
 
-interface RawEditorProps extends QueryEditorProps {
+interface RawEditorProps extends Omit<QueryEditorProps, 'onChange'> {
   onRunQuery: () => void;
+  onChange: (q: BigQueryQueryNG, processQuery: boolean) => void;
 }
 
 export function RawEditor({ apiClient, query, onChange, onRunQuery }: RawEditorProps) {
@@ -86,7 +87,6 @@ export function RawEditor({ apiClient, query, onChange, onRunQuery }: RawEditorP
         getTableSchema={getTableSchema}
         query={query}
         onChange={onChange}
-        onRunQuery={onRunQuery}
       />
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1225,10 +1225,10 @@
     prettier "2.2.1"
     typescript "4.3.4"
 
-"@grafana/experimental@0.0.2-canary.20":
-  version "0.0.2-canary.20"
-  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.20.tgz#06444b6e3cb1d33d1f8b8c7fb65ab0ea03c3eb6d"
-  integrity sha512-G9lxAZ3S2opx8gcfkelu6ZzsjXsgqf63riEk3IdO8Vpel3mb9zjEfpgyj6tu64ErqZJGEve0KlKAl59RotMPGw==
+"@grafana/experimental@0.0.2-canary.21":
+  version "0.0.2-canary.21"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.21.tgz#2c4b2c7744778405295cd03ef36ac21d595e4e4a"
+  integrity sha512-S2Fnf+zUls9hbppZ+Z04y1V6CrjerdGCK+ZZ8RIpEtd7/C9Svc8O4zSV4aXR4vYazw+esg/JZvQpKsQp1X2IvA==
   dependencies:
     "@types/uuid" "^8.3.3"
     uuid "^8.3.2"


### PR DESCRIPTION
1. Updates grafana-experimental to support columns suggestions in WHERE clause and running query by hitting CTRL/CMD+Return
2. Validation now runs on query change (1000ms debounced). Improved errors output.
