### PR TITLE
Enable annotations support

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -74,7 +74,7 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
         <VisualEditor
           apiClient={apiClient}
           query={queryWithDefaults}
-          onChange={onQueryChange}
+          onChange={(q) => onQueryChange(q, false)}
           queryRowFilter={queryRowFilter}
         />
       )}

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -76,20 +76,19 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
           query={queryWithDefaults}
           onChange={(q) => onQueryChange(q, false)}
           queryRowFilter={queryRowFilter}
+          onValidate={setIsQueryRunnable}
         />
       )}
 
       {queryWithDefaults.editorMode === EditorMode.Code && (
-        <>
-          <RawEditor
-            apiClient={apiClient}
-            query={queryWithDefaults}
-            queryToValidate={queryToValidate}
-            onChange={onQueryChange}
-            onRunQuery={onRunQuery}
-            onValidate={setIsQueryRunnable}
-          />
-        </>
+        <RawEditor
+          apiClient={apiClient}
+          query={queryWithDefaults}
+          queryToValidate={queryToValidate}
+          onChange={onQueryChange}
+          onRunQuery={onRunQuery}
+          onValidate={setIsQueryRunnable}
+        />
       )}
     </>
   );

--- a/src/components/QueryHeader.tsx
+++ b/src/components/QueryHeader.tsx
@@ -149,18 +149,17 @@ export function QueryHeader({
 
         <FlexItem grow={1} />
 
-        {editorMode === EditorMode.Code &&
-          (isQueryRunnable ? (
-            <Button icon="play" variant="secondary" size="sm" onClick={() => onRunQuery()}>
+        {isQueryRunnable ? (
+          <Button icon="play" variant="secondary" size="sm" onClick={() => onRunQuery()}>
+            Run query
+          </Button>
+        ) : (
+          <Tooltip theme="error" content="Your query is invalid. Check below for details." placement="top">
+            <Button icon="exclamation-triangle" variant="secondary" size="sm" onClick={() => onRunQuery()}>
               Run query
             </Button>
-          ) : (
-            <Tooltip theme="error" content="Your query is invalid. Check below for details." placement="top">
-              <Button icon="exclamation-triangle" variant="secondary" size="sm" onClick={() => onRunQuery()}>
-                Run query
-              </Button>
-            </Tooltip>
-          ))}
+          </Tooltip>
+        )}
 
         <RadioButtonGroup options={editorModes} size="sm" value={editorMode} onChange={onEditorModeChange} />
 

--- a/src/components/query-editor-raw/QueryValidator.tsx
+++ b/src/components/query-editor-raw/QueryValidator.tsx
@@ -11,10 +11,11 @@ interface QueryValidatorProps {
   apiClient: BigQueryAPI;
   query: BigQueryQueryNG;
   onValidate: (isValid: boolean) => void;
-  onFormatCode: () => void;
+  onFormatCode?: () => void;
+  showHints?: boolean;
 }
 
-export function QueryValidator({ apiClient, query, onValidate, onFormatCode }: QueryValidatorProps) {
+export function QueryValidator({ apiClient, query, onValidate, onFormatCode, showHints }: QueryValidatorProps) {
   const [validationResult, setValidationResult] = useState<ValidationResults | null>();
   const theme = useTheme2();
   const valueFormatter = useMemo(() => getValueFormat('bytes'), []);
@@ -111,14 +112,18 @@ export function QueryValidator({ apiClient, query, onValidate, onFormatCode }: Q
           </>
         )}
       </div>
-      <div>
-        <HorizontalGroup spacing="sm">
-          <IconButton onClick={onFormatCode} name="brackets-curly" size="xs" tooltip="Format query" />
-          <Tooltip content="Hit CTRL/CMD+Return to run query">
-            <Icon className={styles.hint} name="keyboard" />
-          </Tooltip>
-        </HorizontalGroup>
-      </div>
+      {showHints && (
+        <div>
+          <HorizontalGroup spacing="sm">
+            {onFormatCode && (
+              <IconButton onClick={onFormatCode} name="brackets-curly" size="xs" tooltip="Format query" />
+            )}
+            <Tooltip content="Hit CTRL/CMD+Return to run query">
+              <Icon className={styles.hint} name="keyboard" />
+            </Tooltip>
+          </HorizontalGroup>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/query-editor-raw/RawEditor.tsx
+++ b/src/components/query-editor-raw/RawEditor.tsx
@@ -98,6 +98,7 @@ export function RawEditor({ apiClient, query, onChange, onRunQuery, onValidate, 
               query={queryToValidate}
               onValidate={onValidate}
               onFormatCode={formatQuery}
+              showHints
             />
           );
         }}

--- a/src/components/visual-query-builder/VisualEditor.tsx
+++ b/src/components/visual-query-builder/VisualEditor.tsx
@@ -6,40 +6,51 @@ import { BQSelectRow } from './BQSelectRow';
 import { BQWhereRow } from './BQWhereRow';
 import { Preview } from './Preview';
 import { BQGroupByRow } from './BQGroupByRow';
+import { QueryValidator } from 'components/query-editor-raw/QueryValidator';
 
 interface VisualEditorProps extends QueryEditorProps {
   queryRowFilter: QueryRowFilter;
+  onValidate: (isValid: boolean) => void;
 }
-export const VisualEditor: React.FC<VisualEditorProps> = ({ query, apiClient, queryRowFilter, onChange }) => {
+export const VisualEditor: React.FC<VisualEditorProps> = ({
+  query,
+  apiClient,
+  queryRowFilter,
+  onChange,
+  onValidate,
+}) => {
   return (
-    <EditorRows>
-      <EditorRow>
-        <BQSelectRow query={query} onQueryChange={onChange} />
-      </EditorRow>
-      {queryRowFilter.filter && (
+    <>
+      <EditorRows>
         <EditorRow>
-          <EditorField label="Filter by column value" optional>
-            <BQWhereRow apiClient={apiClient} query={query} onQueryChange={onChange} />
-          </EditorField>
+          <BQSelectRow query={query} onQueryChange={onChange} />
         </EditorRow>
-      )}
-      {queryRowFilter.group && (
-        <EditorRow>
-          <EditorField label="Group by column">
-            <BQGroupByRow query={query} onQueryChange={onChange} />
-          </EditorField>
-        </EditorRow>
-      )}
-      {queryRowFilter.order && (
-        <EditorRow>
-          <BQOrderByRow query={query} onQueryChange={onChange} />
-        </EditorRow>
-      )}
-      {queryRowFilter.preview && query.rawSql && (
-        <EditorRow>
-          <Preview rawSql={query.rawSql} />
-        </EditorRow>
-      )}
-    </EditorRows>
+        {queryRowFilter.filter && (
+          <EditorRow>
+            <EditorField label="Filter by column value" optional>
+              <BQWhereRow apiClient={apiClient} query={query} onQueryChange={onChange} />
+            </EditorField>
+          </EditorRow>
+        )}
+        {queryRowFilter.group && (
+          <EditorRow>
+            <EditorField label="Group by column">
+              <BQGroupByRow query={query} onQueryChange={onChange} />
+            </EditorField>
+          </EditorRow>
+        )}
+        {queryRowFilter.order && (
+          <EditorRow>
+            <BQOrderByRow query={query} onQueryChange={onChange} />
+          </EditorRow>
+        )}
+        {queryRowFilter.preview && query.rawSql && (
+          <EditorRow>
+            <Preview rawSql={query.rawSql} />
+          </EditorRow>
+        )}
+      </EditorRows>
+      <QueryValidator apiClient={apiClient} query={query} onValidate={onValidate} />
+    </>
   );
 };

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -15,6 +15,7 @@ export class BigQueryDatasource extends DataSourceWithBackend<BigQueryQueryNG, B
   jsonData: BigQueryOptions;
 
   authenticationType: string;
+  annotations = {};
 
   constructor(instanceSettings: DataSourceInstanceSettings<BigQueryOptions>) {
     super(instanceSettings);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -295,6 +295,7 @@ export function applyQueryDefaults(q: BigQueryQueryNG, ds: BigQueryDatasource) {
     sql: q.sql || {
       columns: [createFunctionField()],
       groupBy: [setGroupByField()],
+      limit: 50,
     },
   };
 

--- a/src/utils/sql.utils.test.ts
+++ b/src/utils/sql.utils.test.ts
@@ -4,7 +4,7 @@ import { applyQueryDefaults } from '../utils';
 import { haveColumns, toRawSql } from './sql.utils';
 
 const queryWithDefaults = applyQueryDefaults({ dataset: 'test', table: 't' } as any, { jsonData: {} } as any);
-const from = 'FROM projectId.test.t';
+const from = 'FROM `projectId.test.t`';
 
 const columns: SQLExpression['columns'] = [
   {

--- a/src/utils/sql.utils.ts
+++ b/src/utils/sql.utils.ts
@@ -19,7 +19,7 @@ export function toRawSql({ sql, dataset, table }: BigQueryQueryNG, projectId: st
   rawQuery += createSelectClause(sql.columns);
 
   if (dataset && table) {
-    rawQuery += `FROM ${projectId}.${dataset}.${table} `;
+    rawQuery += `FROM \`${projectId}.${dataset}.${table}\` `;
   }
 
   if (sql.whereString) {


### PR DESCRIPTION
Apart from enabling the annotations support, the following changes are introduced:

- Visual query builder has now a default limit set for a query (50)
- Queries built with visual query builder are no longer automatically executed- the Run query button is shown as in code editor
- Query produced by visual query builder has table wrapped in backticks
