### PR TITLE
Fix macros interpolation bug

### DIFF
--- a/pkg/bigquery/datasource.go
+++ b/pkg/bigquery/datasource.go
@@ -247,9 +247,10 @@ func (s *BigQueryDatasource) Columns(ctx context.Context, options sqlds.Options)
 }
 
 type ValidateQueryArgs struct {
-	Project  string      `json:"project"`
-	Location string      `json:"location"`
-	Query    sqlds.Query `json:"query"`
+	Project   string            `json:"project"`
+	Location  string            `json:"location"`
+	Query     sqlds.Query       `json:"query"`
+	TimeRange backend.TimeRange `json:"range"`
 }
 
 func (s *BigQueryDatasource) ValidateQuery(ctx context.Context, options ValidateQueryArgs) (*api.ValidateQueryResponse, error) {

--- a/pkg/bigquery/macros.go
+++ b/pkg/bigquery/macros.go
@@ -1,7 +1,6 @@
 package bigquery
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -10,17 +9,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/sqlds/v2"
 )
-
-func macroTable(query *sqlds.Query, args []string) (string, error) {
-	var connArgs ConnectionArgs
-	err := json.Unmarshal(query.ConnectionArgs, &connArgs)
-
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("`%s.%s`", connArgs.Dataset, connArgs.Table), nil
-}
 
 // Example:
 //   $__millisTimeFrom(time) => "time >= '1572480000000'"
@@ -69,7 +57,6 @@ func macroTimeGroup(query *sqlds.Query, args []string) (string, error) {
 }
 
 var macros = map[string]sqlds.MacroFunc{
-	"table":          macroTable,
 	"timeGroup":      macroTimeGroup,
 	"millisTimeFrom": macroMillisTimeFrom,
 	"millisTimeTo":   macroMillisTimeTo,

--- a/pkg/bigquery/macros_test.go
+++ b/pkg/bigquery/macros_test.go
@@ -26,19 +26,6 @@ func Test_macros(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			"table",
-			"table",
-			&sqlds.Query{ConnectionArgs: []byte(
-				`{
-					"dataset" : "dataset",
-					"table" : "table"
-				}`,
-			)},
-			[]string{},
-			"`dataset.table`",
-			nil,
-		},
-		{
 			"time groups 1w",
 			"timeGroup",
 			&sqlds.Query{},

--- a/pkg/bigquery/routes/routes.go
+++ b/pkg/bigquery/routes/routes.go
@@ -68,6 +68,7 @@ func (r *ResourceHandler) validateQuery(rw http.ResponseWriter, req *http.Reques
 		utils.WriteResponse(rw, []byte(err.Error()))
 		return
 	}
+	result.Query.TimeRange = result.TimeRange
 
 	res, err := r.ds.ValidateQuery(req.Context(), result)
 	utils.SendResponse(res, err, rw)

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,4 @@
+import { TimeRange } from '@grafana/data';
 import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { lastValueFrom } from 'rxjs';
 import { BigQueryQueryNG } from 'types';
@@ -41,7 +42,7 @@ export interface BigQueryAPI {
   getTables: (location: string, dataset: string) => Promise<string[]>;
   getTableSchema: (location: string, dataset: string, table: string) => Promise<TableSchema>;
   getColumns: (location: string, dataset: string, table: string, isOrderable?: boolean) => Promise<string[]>;
-  validateQuery: (query: BigQueryQueryNG) => Promise<ValidationResults>;
+  validateQuery: (query: BigQueryQueryNG, range?: TimeRange) => Promise<ValidationResults>;
   dispose: () => void;
 }
 
@@ -83,7 +84,7 @@ class BigQueryAPIClient implements BigQueryAPI {
     });
   };
 
-  validateQuery = async (query: BigQueryQueryNG): Promise<ValidationResults> => {
+  validateQuery = async (query: BigQueryQueryNG, range?: TimeRange): Promise<ValidationResults> => {
     const rawSql = getTemplateSrv().replace(query.rawSql);
 
     if (this.lastValidation && rawSql === this.lastValidation.query) {
@@ -97,6 +98,7 @@ class BigQueryAPIClient implements BigQueryAPI {
         ...query,
         rawSql,
       },
+      range,
     });
 
     this.lastValidation = {

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -12,7 +12,7 @@ import { VisualEditor } from './visual-query-builder/VisualEditor';
 
 type Props = QueryEditorProps<BigQueryDatasource, BigQueryQueryNG, BigQueryOptions>;
 
-export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) {
+export function QueryEditor({ datasource, query, onChange, onRunQuery, range }: Props) {
   setDatasourceId(datasource.id);
   const [isQueryRunnable, setIsQueryRunnable] = useState(true);
   const { loading: apiLoading, error: apiError, value: apiClient } = useAsync(
@@ -77,6 +77,7 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
           onChange={(q) => onQueryChange(q, false)}
           queryRowFilter={queryRowFilter}
           onValidate={setIsQueryRunnable}
+          range={range}
         />
       )}
 
@@ -88,6 +89,7 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
           onChange={onQueryChange}
           onRunQuery={onRunQuery}
           onValidate={setIsQueryRunnable}
+          range={range}
         />
       )}
     </>

--- a/src/components/query-editor-raw/QueryValidator.tsx
+++ b/src/components/query-editor-raw/QueryValidator.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { formattedValueToString, getValueFormat } from '@grafana/data';
+import { formattedValueToString, getValueFormat, TimeRange } from '@grafana/data';
 import { Icon, IconButton, Spinner, useTheme2, HorizontalGroup, Tooltip } from '@grafana/ui';
 import { BigQueryAPI, ValidationResults } from 'api';
 import React, { useState, useMemo, useEffect } from 'react';
@@ -13,9 +13,10 @@ interface QueryValidatorProps {
   onValidate: (isValid: boolean) => void;
   onFormatCode?: () => void;
   showHints?: boolean;
+  range?: TimeRange;
 }
 
-export function QueryValidator({ apiClient, query, onValidate, onFormatCode, showHints }: QueryValidatorProps) {
+export function QueryValidator({ apiClient, query, onValidate, onFormatCode, showHints, range }: QueryValidatorProps) {
   const [validationResult, setValidationResult] = useState<ValidationResults | null>();
   const theme = useTheme2();
   const valueFormatter = useMemo(() => getValueFormat('bytes'), []);
@@ -55,7 +56,7 @@ export function QueryValidator({ apiClient, query, onValidate, onFormatCode, sho
         return null;
       }
 
-      return await apiClient.validateQuery(q);
+      return await apiClient.validateQuery(q, range);
     },
     [apiClient]
   );

--- a/src/components/query-editor-raw/RawEditor.tsx
+++ b/src/components/query-editor-raw/RawEditor.tsx
@@ -11,7 +11,15 @@ interface RawEditorProps extends Omit<QueryEditorProps, 'onChange'> {
   queryToValidate: BigQueryQueryNG;
 }
 
-export function RawEditor({ apiClient, query, onChange, onRunQuery, onValidate, queryToValidate }: RawEditorProps) {
+export function RawEditor({
+  apiClient,
+  query,
+  onChange,
+  onRunQuery,
+  onValidate,
+  queryToValidate,
+  range,
+}: RawEditorProps) {
   const getColumns = useCallback(
     // expects fully qualified table name: <project-id>.<dataset-id>.<table-id>
     async (t: string) => {
@@ -99,6 +107,7 @@ export function RawEditor({ apiClient, query, onChange, onRunQuery, onValidate, 
               onValidate={onValidate}
               onFormatCode={formatQuery}
               showHints
+              range={range}
             />
           );
         }}

--- a/src/components/visual-query-builder/VisualEditor.tsx
+++ b/src/components/visual-query-builder/VisualEditor.tsx
@@ -18,6 +18,7 @@ export const VisualEditor: React.FC<VisualEditorProps> = ({
   queryRowFilter,
   onChange,
   onValidate,
+  range,
 }) => {
   return (
     <>
@@ -50,7 +51,7 @@ export const VisualEditor: React.FC<VisualEditorProps> = ({
           </EditorRow>
         )}
       </EditorRows>
-      <QueryValidator apiClient={apiClient} query={query} onValidate={onValidate} />
+      <QueryValidator apiClient={apiClient} query={query} onValidate={onValidate} range={range} />
     </>
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { DataQuery, DataSourceJsonData } from '@grafana/data';
+import { DataQuery, DataSourceJsonData, TimeRange } from '@grafana/data';
 import { EditorMode } from '@grafana/experimental';
 import { BigQueryAPI } from 'api';
 import {
@@ -105,4 +105,5 @@ export interface QueryEditorProps {
   apiClient: BigQueryAPI;
   query: QueryWithDefaults;
   onChange: (query: BigQueryQueryNG) => void;
+  range?: TimeRange;
 }


### PR DESCRIPTION
Time range was not provided when sending the query validation request, resulting in wrong `timeFilter` macro interpolation.
Also removed `table` macro which is no longer relevant. 