### PR TITLE
Fix reseting JWT settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## 0.1.13
+
+- **Data source settings**: Fix bug, that made it impossible to reset and change JWT token used for authentication.
+
 ## 0.1.12
 
 - **Annotations**: Add annotation support.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Google BigQuery datasource for Grafana",
   "scripts": {
     "dev": "grafana-toolkit plugin:dev",

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -71,7 +71,7 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
       {isJWT && (
         <FieldSet label="JWT Key Details">
           {hasJWTConfigured ? (
-            <JWTForm options={options.jsonData} onReset={onResetApiKey} onChange={onJWTFormChange} />
+            <JWTForm options={options.jsonData} onReset={() => onResetApiKey()} onChange={onJWTFormChange} />
           ) : (
             <JWTConfigEditor
               onChange={(jwt) => {


### PR DESCRIPTION
By accident, the reset function was called with the entire click event object making it impossible to reset once set JWT token.

Fixes https://github.com/grafana/google-bigquery-datasource/issues/65