### PR TITLE
Code editor: Add possibility to edit query in an expanded editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@emotion/css": "11.1.3",
     "@grafana/data": "canary",
-    "@grafana/experimental": "0.0.2-canary.23",
+    "@grafana/experimental": "0.0.2-canary.24",
     "@grafana/runtime": "canary",
     "@grafana/ui": "canary",
     "brace": "^0.10.0",
@@ -27,6 +27,7 @@
     "q": "^1.5.1",
     "react-awesome-query-builder": "^4.8.0",
     "react-use": "^17.3.1",
+    "react-virtualized-auto-sizer": "^1.0.6",
     "rxjs": "7.5.1",
     "sql-formatter-plus": "^1.3.6",
     "uuid": "^8.3.2"
@@ -38,6 +39,7 @@
     "@testing-library/react": "^12.1.0",
     "@types/grafana": "https://git@github.com/CorpGlory/types-grafana.git",
     "@types/lodash": "^4.14.173",
+    "@types/react-virtualized-auto-sizer": "^1.0.1",
     "@types/uuid": "^8.3.1",
     "googleapis": "^49.0.0",
     "grafana-sdk-mocks": "github:grafana/grafana-sdk-mocks"

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -89,6 +89,7 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery, range }: 
           onChange={onQueryChange}
           onRunQuery={onRunQuery}
           onValidate={setIsQueryRunnable}
+          isQueryRunnable={isQueryRunnable}
           range={range}
         />
       )}

--- a/src/components/QueryHeader.tsx
+++ b/src/components/QueryHeader.tsx
@@ -152,11 +152,20 @@ export function QueryHeader({
         <FlexItem grow={1} />
 
         {isQueryRunnable ? (
-          <Button icon="play" variant="secondary" size="sm" onClick={() => onRunQuery()}>
+          <Button icon="play" variant="primary" size="sm" onClick={() => onRunQuery()}>
             Run query
           </Button>
         ) : (
-          <Tooltip theme="error" content="Your query is invalid. Check below for details." placement="top">
+          <Tooltip
+            theme="error"
+            content={
+              <>
+                Your query is invalid. Check below for details. <br />
+                However, you can still run this query.
+              </>
+            }
+            placement="top"
+          >
             <Button icon="exclamation-triangle" variant="secondary" size="sm" onClick={() => onRunQuery()}>
               Run query
             </Button>

--- a/src/components/query-editor-raw/QueryEditorRaw.tsx
+++ b/src/components/query-editor-raw/QueryEditorRaw.tsx
@@ -12,6 +12,8 @@ type Props = {
   getTableSchema: (l: string, d: string, t: string) => Promise<TableSchema | null>;
   onChange: (value: BigQueryQueryNG, processQuery: boolean) => void;
   children?: (props: { formatQuery: () => void }) => React.ReactNode;
+  width?: number;
+  height?: number;
 };
 
 export function QueryEditorRaw({
@@ -21,6 +23,8 @@ export function QueryEditorRaw({
   getTableSchema: apiGetTableSchema,
   onChange,
   query,
+  width,
+  height,
 }: Props) {
   const getColumns = useRef<Props['getColumns']>(apiGetColumns);
   const getTables = useRef<Props['getTables']>(apiGetTables);
@@ -50,6 +54,8 @@ export function QueryEditorRaw({
 
   return (
     <SQLEditor
+      width={width}
+      height={height}
       query={query.rawSql}
       onChange={onRawQueryChange}
       language={{ id: 'bigquery', completionProvider, formatter: formatSQL }}

--- a/src/components/query-editor-raw/QueryToolbox.tsx
+++ b/src/components/query-editor-raw/QueryToolbox.tsx
@@ -1,0 +1,89 @@
+import React, { useMemo, useState } from 'react';
+import { HorizontalGroup, Icon, IconButton, Tooltip, useTheme2 } from '@grafana/ui';
+import { QueryValidator, QueryValidatorProps } from './QueryValidator';
+import { css } from '@emotion/css';
+
+interface QueryToolboxProps extends Omit<QueryValidatorProps, 'onValidate'> {
+  showTools?: boolean;
+  isExpanded?: boolean;
+  onFormatCode?: () => void;
+  onExpand?: (expand: boolean) => void;
+  onValidate?: (isValid: boolean) => void;
+}
+
+export function QueryToolbox({ showTools, onFormatCode, onExpand, isExpanded, ...validatorProps }: QueryToolboxProps) {
+  const theme = useTheme2();
+  const [validationResult, setValidationResult] = useState<boolean>();
+
+  const styles = useMemo(() => {
+    return {
+      container: css`
+        border: 1px solid ${theme.colors.border.medium};
+        border-top: none;
+        padding: ${theme.spacing(0.5, 0.5, 0.5, 0.5)};
+        display: flex;
+        flex-grow: 1;
+        justify-content: space-between;
+        font-size: ${theme.typography.bodySmall.fontSize};
+      `,
+      error: css`
+        color: ${theme.colors.error.text};
+        font-size: ${theme.typography.bodySmall.fontSize};
+        font-family: ${theme.typography.fontFamilyMonospace};
+      `,
+      valid: css`
+        color: ${theme.colors.success.text};
+      `,
+      info: css`
+        color: ${theme.colors.text.secondary};
+      `,
+      hint: css`
+        color: ${theme.colors.text.disabled};
+        white-space: nowrap;
+        cursor: help;
+      `,
+    };
+  }, [theme]);
+
+  let style = {};
+
+  if (!showTools && validationResult == undefined) {
+    style = { height: 0, padding: 0, visibility: 'hidden' };
+  }
+
+  return (
+    <div className={styles.container} style={style}>
+      <div>
+        {validatorProps.onValidate && (
+          <QueryValidator
+            {...validatorProps}
+            onValidate={(result) => {
+              setValidationResult(result);
+              validatorProps.onValidate!(result);
+            }}
+          />
+        )}
+      </div>
+      {showTools && (
+        <div>
+          <HorizontalGroup spacing="sm">
+            {onFormatCode && (
+              <IconButton onClick={onFormatCode} name="brackets-curly" size="xs" tooltip="Format query" />
+            )}
+            {onExpand && (
+              <IconButton
+                onClick={() => onExpand(!isExpanded)}
+                name={isExpanded ? 'compress-arrows' : ('expand-arrows-alt' as any)}
+                size="xs"
+                tooltip={isExpanded ? 'Collapse editor' : 'Expand editor'}
+              />
+            )}
+            <Tooltip content="Hit CTRL/CMD+Return to run query">
+              <Icon className={styles.hint} name="keyboard" />
+            </Tooltip>
+          </HorizontalGroup>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/query-editor-raw/QueryValidator.tsx
+++ b/src/components/query-editor-raw/QueryValidator.tsx
@@ -1,36 +1,26 @@
 import { css } from '@emotion/css';
 import { formattedValueToString, getValueFormat, TimeRange } from '@grafana/data';
-import { Icon, IconButton, Spinner, useTheme2, HorizontalGroup, Tooltip } from '@grafana/ui';
+import { Icon, Spinner, useTheme2 } from '@grafana/ui';
 import { BigQueryAPI, ValidationResults } from 'api';
 import React, { useState, useMemo, useEffect } from 'react';
 import { useAsyncFn } from 'react-use';
 import useDebounce from 'react-use/lib/useDebounce';
 import { BigQueryQueryNG } from 'types';
 
-interface QueryValidatorProps {
+export interface QueryValidatorProps {
   apiClient: BigQueryAPI;
   query: BigQueryQueryNG;
-  onValidate: (isValid: boolean) => void;
-  onFormatCode?: () => void;
-  showHints?: boolean;
   range?: TimeRange;
+  onValidate: (isValid: boolean) => void;
 }
 
-export function QueryValidator({ apiClient, query, onValidate, onFormatCode, showHints, range }: QueryValidatorProps) {
+export function QueryValidator({ apiClient, query, onValidate, range }: QueryValidatorProps) {
   const [validationResult, setValidationResult] = useState<ValidationResults | null>();
   const theme = useTheme2();
   const valueFormatter = useMemo(() => getValueFormat('bytes'), []);
 
   const styles = useMemo(() => {
     return {
-      container: css`
-        border: 1px solid ${theme.colors.border.medium};
-        border-top: none;
-        padding: ${theme.spacing(0.5, 0.5, 0.5, 0.5)};
-        display: flex;
-        justify-content: space-between;
-        font-size: ${theme.typography.bodySmall.fontSize};
-      `,
       error: css`
         color: ${theme.colors.error.text};
         font-size: ${theme.typography.bodySmall.fontSize};
@@ -41,11 +31,6 @@ export function QueryValidator({ apiClient, query, onValidate, onFormatCode, sho
       `,
       info: css`
         color: ${theme.colors.text.secondary};
-      `,
-      hint: css`
-        color: ${theme.colors.text.disabled};
-        white-space: nowrap;
-        cursor: help;
       `,
     };
   }, [theme]);
@@ -90,42 +75,28 @@ export function QueryValidator({ apiClient, query, onValidate, onFormatCode, sho
   const error = state.value?.error ? processErrorMessage(state.value.error) : '';
 
   return (
-    <div className={styles.container}>
-      <div>
-        {state.loading && (
-          <div className={styles.info}>
-            <Spinner inline={true} size={12} /> Validating query...
-          </div>
-        )}
-        {!state.loading && state.value && (
-          <>
-            <>
-              {state.value.isValid && state.value.statistics && (
-                <div className={styles.valid}>
-                  <Icon name="check" /> This query will process{' '}
-                  <strong>{formattedValueToString(valueFormatter(state.value.statistics.TotalBytesProcessed))}</strong>{' '}
-                  when run.
-                </div>
-              )}
-            </>
-
-            <>{state.value.isError && <div className={styles.error}>{error}</div>}</>
-          </>
-        )}
-      </div>
-      {showHints && (
-        <div>
-          <HorizontalGroup spacing="sm">
-            {onFormatCode && (
-              <IconButton onClick={onFormatCode} name="brackets-curly" size="xs" tooltip="Format query" />
-            )}
-            <Tooltip content="Hit CTRL/CMD+Return to run query">
-              <Icon className={styles.hint} name="keyboard" />
-            </Tooltip>
-          </HorizontalGroup>
+    <>
+      {state.loading && (
+        <div className={styles.info}>
+          <Spinner inline={true} size={12} /> Validating query...
         </div>
       )}
-    </div>
+      {!state.loading && state.value && (
+        <>
+          <>
+            {state.value.isValid && state.value.statistics && (
+              <div className={styles.valid}>
+                <Icon name="check" /> This query will process{' '}
+                <strong>{formattedValueToString(valueFormatter(state.value.statistics.TotalBytesProcessed))}</strong>{' '}
+                when run.
+              </div>
+            )}
+          </>
+
+          <>{state.value.isError && <div className={styles.error}>{error}</div>}</>
+        </>
+      )}
+    </>
   );
 }
 

--- a/src/components/query-editor-raw/RawEditor.tsx
+++ b/src/components/query-editor-raw/RawEditor.tsx
@@ -1,14 +1,19 @@
 import { QueryEditorRaw } from './QueryEditorRaw';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { getColumnInfoFromSchema } from 'utils/getColumnInfoFromSchema';
 import { BigQueryQueryNG, QueryEditorProps } from 'types';
-import { QueryValidator } from './QueryValidator';
+import { QueryToolbox } from './QueryToolbox';
+import { Modal, useTheme2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { useMeasure } from 'react-use';
 
 interface RawEditorProps extends Omit<QueryEditorProps, 'onChange'> {
   onRunQuery: () => void;
   onChange: (q: BigQueryQueryNG, processQuery: boolean) => void;
   onValidate: (isValid: boolean) => void;
   queryToValidate: BigQueryQueryNG;
+  isQueryRunnable: boolean;
 }
 
 export function RawEditor({
@@ -18,8 +23,27 @@ export function RawEditor({
   onRunQuery,
   onValidate,
   queryToValidate,
+  isQueryRunnable,
   range,
 }: RawEditorProps) {
+  const theme = useTheme2();
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [toolboxRef, toolboxMeasure] = useMeasure<HTMLDivElement>();
+  const [editorRef, editorMeasure] = useMeasure<HTMLDivElement>();
+
+  const styles = useMemo(() => {
+    return {
+      modal: css`
+        width: 95vw;
+        height: 95vh;
+      `,
+      modalContent: css`
+        height: 100%;
+        padding-top: 0;
+      `,
+    };
+  }, []);
+
   const getColumns = useCallback(
     // expects fully qualified table name: <project-id>.<dataset-id>.<table-id>
     async (t: string) => {
@@ -90,28 +114,88 @@ export function RawEditor({
     },
     [apiClient]
   );
-  return (
-    <>
+
+  const renderQueryEditor = (width?: number, height?: number) => {
+    return (
       <QueryEditorRaw
         getTables={getTables}
         getColumns={getColumns}
         getTableSchema={getTableSchema}
         query={query}
+        width={width}
+        height={height ? height - toolboxMeasure.height : undefined}
         onChange={onChange}
       >
         {({ formatQuery }) => {
           return (
-            <QueryValidator
-              apiClient={apiClient}
-              query={queryToValidate}
-              onValidate={onValidate}
-              onFormatCode={formatQuery}
-              showHints
-              range={range}
-            />
+            <div ref={toolboxRef}>
+              <QueryToolbox
+                apiClient={apiClient}
+                query={queryToValidate}
+                onValidate={onValidate}
+                onFormatCode={formatQuery}
+                showTools
+                range={range}
+                onExpand={setIsExpanded}
+                isExpanded={isExpanded}
+              />
+            </div>
           );
         }}
       </QueryEditorRaw>
+    );
+  };
+
+  const renderEditor = (standalone = false) => {
+    return standalone ? (
+      <AutoSizer>
+        {({ width, height }) => {
+          return renderQueryEditor(width, height);
+        }}
+      </AutoSizer>
+    ) : (
+      <div ref={editorRef}>{renderQueryEditor()}</div>
+    );
+  };
+
+  const renderPlaceholder = () => {
+    return (
+      <div
+        style={{
+          width: editorMeasure.width,
+          height: editorMeasure.height,
+          background: theme.colors.background.primary,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        Editing in expanded code editor
+      </div>
+    );
+  };
+
+  return (
+    <>
+      {isExpanded ? renderPlaceholder() : renderEditor()}
+      {isExpanded && (
+        <Modal
+          title={`Query ${query.refId}`}
+          closeOnBackdropClick={false}
+          closeOnEscape={false}
+          className={styles.modal}
+          contentClassName={styles.modalContent}
+          isOpen={isExpanded}
+          onDismiss={() => {
+            if (isQueryRunnable) {
+              onRunQuery();
+            }
+            setIsExpanded(false);
+          }}
+        >
+          {renderEditor(true)}
+        </Modal>
+      )}
     </>
   );
 }

--- a/src/components/visual-query-builder/VisualEditor.tsx
+++ b/src/components/visual-query-builder/VisualEditor.tsx
@@ -6,7 +6,7 @@ import { BQSelectRow } from './BQSelectRow';
 import { BQWhereRow } from './BQWhereRow';
 import { Preview } from './Preview';
 import { BQGroupByRow } from './BQGroupByRow';
-import { QueryValidator } from 'components/query-editor-raw/QueryValidator';
+import { QueryToolbox } from 'components/query-editor-raw/QueryToolbox';
 
 interface VisualEditorProps extends QueryEditorProps {
   queryRowFilter: QueryRowFilter;
@@ -51,7 +51,7 @@ export const VisualEditor: React.FC<VisualEditorProps> = ({
           </EditorRow>
         )}
       </EditorRows>
-      <QueryValidator apiClient={apiClient} query={query} onValidate={onValidate} range={range} />
+      <QueryToolbox apiClient={apiClient} query={query} onValidate={onValidate} range={range} />
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,10 +1233,10 @@
     prettier "2.2.1"
     typescript "4.3.4"
 
-"@grafana/experimental@0.0.2-canary.23":
-  version "0.0.2-canary.23"
-  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.23.tgz#42614f4a19de34cab01b8232b87b94b556d6260e"
-  integrity sha512-hYnQ4rfx6cdokYioHNi0vlOrU7/M1H4qrEMgl9ePWlz8LSkuSD2dnk+agTtPqgVePDta1fawODZ7ZS41G5fE2g==
+"@grafana/experimental@0.0.2-canary.24":
+  version "0.0.2-canary.24"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.24.tgz#43fb640529270428a9b2a0a583437aa4560fc0a2"
+  integrity sha512-5PY0ld0/+urrSQ5j3Lo/sDDWYRy9axrdx2dB5wJjVmqOAZut7OfM3iFwS0rAktQcY8e3lKm73XMFfPZdB+xC7w==
   dependencies:
     "@types/uuid" "^8.3.3"
     uuid "^8.3.2"
@@ -2501,6 +2501,13 @@
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
   integrity sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-virtualized-auto-sizer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.1.tgz#b3187dae1dfc4c15880c9cfc5b45f2719ea6ebd4"
+  integrity sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong==
   dependencies:
     "@types/react" "*"
 
@@ -10632,6 +10639,11 @@ react-use@17.3.2, react-use@^17.3.1:
     throttle-debounce "^3.0.1"
     ts-easing "^0.2.0"
     tslib "^2.1.0"
+
+react-virtualized-auto-sizer@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz#66c5b1c9278064c5ef1699ed40a29c11518f97ca"
+  integrity sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==
 
 react-window@1.8.6:
   version "1.8.6"


### PR DESCRIPTION
This PR brings a UI improvement to query editing. A new mode was added to the code editor, that opens the editor in almost-fullscreen modal:

https://user-images.githubusercontent.com/2376619/161760439-2ddd7a73-e77c-4670-ab42-7bd87f9f8c75.mov

When the expanded editor is closed and the query is valid, it will be automatically processed.

Also, this PR introduces a small improvement to the UX of the `Run Query` button which becomes highlighted if the query is valid:

https://user-images.githubusercontent.com/2376619/161760803-1465bb47-01f2-49b4-b21f-f74bf7f48f3d.mov


