### PR TITLE
GCE auth: Allow configuring default project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+- **Authentication**: Allow configuring default project when using GCE authentication.
+
 ## 1.0.0
 
 - **Visual Query Builder**: Support IS [NOT] NULL operator.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Google BigQuery datasource for Grafana",
   "scripts": {
     "dev": "grafana-toolkit plugin:dev",

--- a/pkg/bigquery/routes/routes.go
+++ b/pkg/bigquery/routes/routes.go
@@ -25,6 +25,10 @@ func (r *ResourceHandler) defaultProjects(rw http.ResponseWriter, req *http.Requ
 	}
 
 	if s.AuthenticationType == "gce" {
+		if s.DefaultProject != "" {
+			utils.SendResponse(s.DefaultProject, nil, rw)
+			return
+		}
 		res, err := r.ds.GetGCEDefaultProject(req.Context())
 		utils.SendResponse(res, err, rw)
 	} else {

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -3,7 +3,7 @@ import {
   onUpdateDatasourceJsonDataOption,
   onUpdateDatasourceJsonDataOptionSelect,
 } from '@grafana/data';
-import { Field, FieldSet, RadioButtonGroup, Select } from '@grafana/ui';
+import { Field, FieldSet, Input, RadioButtonGroup, Select } from '@grafana/ui';
 
 import React from 'react';
 import { JWTConfigEditor } from './JWTConfigEditor';
@@ -17,7 +17,6 @@ export type BigQueryConfigEditorProps = DataSourcePluginOptionsEditorProps<BigQu
 export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props) => {
   const { options, onOptionsChange } = props;
   const { jsonData, secureJsonFields, secureJsonData } = options;
-
   if (!jsonData.authenticationType) {
     jsonData.authenticationType = GoogleAuthType.JWT;
   }
@@ -96,6 +95,16 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
       )}
 
       <FieldSet label="Other settings">
+        {!isJWT && (
+          <Field label="Default project">
+            <Input
+              id="defaultProject"
+              width={60}
+              value={jsonData.defaultProject || ''}
+              onChange={onUpdateDatasourceJsonDataOption(props, 'defaultProject')}
+            />
+          </Field>
+        )}
         <Field
           label="Processing location"
           description={


### PR DESCRIPTION
Ref: https://github.com/grafana/google-bigquery-datasource/issues/101

Brings possibility to configure a default project in GCE auth scenario.