### PR TITLE
GCE auth: Fix default project not being used when querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.2
+
+- **Fix**: Use configured default project when using GCE authentication.
+
 ## 1.0.1
 
 - **Authentication**: Allow configuring default project when using GCE authentication.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Google BigQuery datasource for Grafana",
   "scripts": {
     "dev": "grafana-toolkit plugin:dev",

--- a/pkg/bigquery/datasource.go
+++ b/pkg/bigquery/datasource.go
@@ -74,7 +74,7 @@ func (s *BigQueryDatasource) Connect(config backend.DataSourceInstanceSettings, 
 
 	connectionSettings := getConnectionSettings(settings, args)
 
-	if settings.AuthenticationType == "gce" {
+	if settings.AuthenticationType == "gce" && connectionSettings.Project == "" {
 		defaultProject, err := s.GetGCEDefaultProject(context.Background())
 		if err != nil {
 			return nil, errors.WithMessage(err, "Failed to retrieve default GCE project")

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -96,7 +96,7 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
 
       <FieldSet label="Other settings">
         {!isJWT && (
-          <Field label="Default project">
+          <Field label="Default project" description="GCP project where BigQuery jobs will be created">
             <Input
               id="defaultProject"
               width={60}


### PR DESCRIPTION
This should allow the scenario described in https://github.com/grafana/google-bigquery-datasource/issues/101#issuecomment-1101420096