### PR TITLE
Code editor: Fix location being reset when raw query is modified

### DIFF
--- a/src/components/query-editor-raw/QueryEditorRaw.tsx
+++ b/src/components/query-editor-raw/QueryEditorRaw.tsx
@@ -35,6 +35,12 @@ export function QueryEditorRaw({
     []
   );
 
+  // We need to pass query via ref to SQLEditor as onChange is executed via monacoEditor.onDidChangeModelContent callback, not onChange property
+  const queryRef = useRef<BigQueryQueryNG>(query);
+  useEffect(() => {
+    queryRef.current = query;
+  }, [query]);
+
   useEffect(() => {
     getColumns.current = apiGetColumns;
     getTables.current = apiGetTables;
@@ -43,13 +49,13 @@ export function QueryEditorRaw({
   const onRawQueryChange = useCallback(
     (rawSql: string, processQuery: boolean) => {
       const newQuery = {
-        ...query,
+        ...queryRef.current,
         rawQuery: true,
         rawSql,
       };
       onChange(newQuery, processQuery);
     },
-    [onChange, query]
+    [onChange]
   );
 
   return (


### PR DESCRIPTION
Fixes https://github.com/grafana/google-bigquery-datasource/issues/113

The problem is caused by how the onChange is handled in the SQLEditor. Since it's executed via [`monacoEditor.onDidChangeModelContent`](https://github.com/grafana/grafana-experimental/blob/main/src/sql-editor/components/SQLEditor.tsx#L115) that doesn't change between re-renders, we need to provide the query via reference  for the callback to use the latest value of the query.