### PR TITLE
Update  @grafana/experimental dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@emotion/css": "11.1.3",
     "@grafana/data": "canary",
-    "@grafana/experimental": "0.0.2-canary.26",
+    "@grafana/experimental": "0.0.2-canary.30",
     "@grafana/runtime": "canary",
     "@grafana/ui": "canary",
     "brace": "^0.10.0",

--- a/src/components/visual-query-builder/SQLOrderByRow.tsx
+++ b/src/components/visual-query-builder/SQLOrderByRow.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import { SelectableValue, toOption } from '@grafana/data';
 import { EditorField, Space } from '@grafana/experimental';
 import { Input, RadioButtonGroup, Select } from '@grafana/ui';
@@ -57,7 +58,11 @@ export function SQLOrderByRow({ sql, onSqlChange, columns, showOffset }: SQLOrde
   return (
     <>
       <EditorField label="Order by" width={25}>
-        <>
+        <div
+          className={css`
+            display: flex;
+          `}
+        >
           <Select
             aria-label="Order by"
             options={columns}
@@ -75,7 +80,7 @@ export function SQLOrderByRow({ sql, onSqlChange, columns, showOffset }: SQLOrde
             value={sql.orderByDirection}
             onChange={onSortOrderChange}
           />
-        </>
+        </div>
       </EditorField>
       <EditorField label="Limit" optional width={25}>
         <Input type="number" min={0} id={uniqueId('limit-')} value={sql.limit || ''} onChange={onLimitChange} />

--- a/src/components/visual-query-builder/SQLOrderByRow.tsx
+++ b/src/components/visual-query-builder/SQLOrderByRow.tsx
@@ -1,6 +1,5 @@
-import { css } from '@emotion/css';
 import { SelectableValue, toOption } from '@grafana/data';
-import { EditorField, Space } from '@grafana/experimental';
+import { EditorField, InputGroup, Space } from '@grafana/experimental';
 import { Input, RadioButtonGroup, Select } from '@grafana/ui';
 import { uniqueId } from 'lodash';
 import React, { useCallback } from 'react';
@@ -58,11 +57,7 @@ export function SQLOrderByRow({ sql, onSqlChange, columns, showOffset }: SQLOrde
   return (
     <>
       <EditorField label="Order by" width={25}>
-        <div
-          className={css`
-            display: flex;
-          `}
-        >
+        <InputGroup>
           <Select
             aria-label="Order by"
             options={columns}
@@ -80,7 +75,7 @@ export function SQLOrderByRow({ sql, onSqlChange, columns, showOffset }: SQLOrde
             value={sql.orderByDirection}
             onChange={onSortOrderChange}
           />
-        </div>
+        </InputGroup>
       </EditorField>
       <EditorField label="Limit" optional width={25}>
         <Input type="number" min={0} id={uniqueId('limit-')} value={sql.limit || ''} onChange={onLimitChange} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,10 +1233,10 @@
     prettier "2.2.1"
     typescript "4.3.4"
 
-"@grafana/experimental@0.0.2-canary.26":
-  version "0.0.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.26.tgz#0df0fdb03b7f63bfbc16dcf32bbc798d518f1a89"
-  integrity sha512-ROSNHElmDzr/Vh+WiddFLKTWWRBH2qAE8jzqZzRyE/vOHphCmm7fEWH7T6SO/CRRYPsjqtoCmndAWD9TMxWk3w==
+"@grafana/experimental@0.0.2-canary.30":
+  version "0.0.2-canary.30"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.30.tgz#e43c8cdf4ea4bb1ef0589aaae3a24320160d01e3"
+  integrity sha512-gWnMBZ4i0Wp01AGq1peCEbgnZlN1khgWtpd6UBkrLnzWeOuXjNp1WZG/3+fKXLjM65ql+bB/fCGg6bTQCgSGTg==
   dependencies:
     "@types/uuid" "^8.3.3"
     uuid "^8.3.2"


### PR DESCRIPTION
In https://github.com/grafana/grafana-experimental/pull/30/files I have removed the hack around aligning switch and created EditorSwitch component. There is a more context on why this was necessary here: https://raintank-corp.slack.com/archives/CHKLEJ668/p1650617120848589

As I know that bigquery uses `<EditorField />` component, I looked trough the code and tried to find all places where there could be regression. I found only this one and created this PR to fix this. 

Could you please manually review code editor before merging this to make sure there weren't any other regressions. 