### PR TITLE
Fix: backward compatibility issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1
+
+- **Fix:** Compatibility issue with Grafana version 8.0.0 (#121)
+
 ## 1.1.0
 
 This release comes with a new feature that enables using multiple BigQuery projects using a single data source. In order to see GCP projects listed in the query editor, you need to enable the [Google Cloud Resource Manager API](https://cloud.google.com/resource-manager).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Google BigQuery datasource for Grafana",
   "scripts": {
     "dev": "grafana-toolkit plugin:dev",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@emotion/css": "11.1.3",
     "@grafana/data": "canary",
-    "@grafana/experimental": "0.0.2-canary.30",
+    "@grafana/experimental": "0.0.2-canary.31",
     "@grafana/runtime": "canary",
     "@grafana/ui": "canary",
     "brace": "^0.10.0",

--- a/src/components/DatasetSelector.tsx
+++ b/src/components/DatasetSelector.tsx
@@ -1,8 +1,9 @@
-import { SelectableValue, toOption } from '@grafana/data';
+import { SelectableValue } from '@grafana/data';
 import { Select } from '@grafana/ui';
 import React, { useEffect } from 'react';
 import { useAsync } from 'react-use';
 import { ResourceSelectorProps } from 'types';
+import { toOption } from 'utils/data';
 
 interface DatasetSelectorProps extends ResourceSelectorProps {
   value: string | null;

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+type Props = {
+  fallBackComponent?: React.ReactNode;
+};
+
+export class ErrorBoundary extends React.Component<Props, { hasError: boolean }> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      const FallBack = this.props.fallBackComponent || <div>Error</div>;
+      return FallBack;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/JWTConfigEditor.tsx
+++ b/src/components/JWTConfigEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, isValidElement } from 'react';
+import React, { useState, useCallback } from 'react';
 import { isObject } from 'lodash';
 import { FileDropzone, TextArea, LinkButton, useTheme2, Field, Button } from '@grafana/ui';
 import { TEST_IDS } from 'utils/testIds';
@@ -73,7 +73,7 @@ export const JWTConfigEditor: React.FC<Props> = ({ onChange }) => {
           {isPasting !== true && (
             <div data-testid={TEST_IDS.dropZone}>
               {/* Backward compatibility check. FileDropzone added in 8.1 */}
-              {isValidElement(FileDropzone) && (
+              {FileDropzone && (
                 <FileDropzone
                   options={{ multiple: false, accept: 'application/json' }}
                   readAs="readAsText"

--- a/src/components/JWTConfigEditor.tsx
+++ b/src/components/JWTConfigEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, isValidElement } from 'react';
 import { isObject } from 'lodash';
 import { FileDropzone, TextArea, LinkButton, useTheme2, Field, Button } from '@grafana/ui';
 import { TEST_IDS } from 'utils/testIds';
@@ -72,21 +72,24 @@ export const JWTConfigEditor: React.FC<Props> = ({ onChange }) => {
         <>
           {isPasting !== true && (
             <div data-testid={TEST_IDS.dropZone}>
-              <FileDropzone
-                options={{ multiple: false, accept: 'application/json' }}
-                readAs="readAsText"
-                onLoad={(result) => {
-                  readAndValidateJWT(result as string);
-                  setIsPasting(false);
-                }}
-              >
-                <p style={{ margin: 0, fontSize: `${theme.typography.h4.fontSize}`, textAlign: 'center' }}>
-                  Drop the Google JWT file here
-                  <br />
-                  <br />
-                  <LinkButton fill="outline">Click to browse files</LinkButton>
-                </p>
-              </FileDropzone>
+              {/* Backward compatibility check. FileDropzone added in 8.1 */}
+              {isValidElement(FileDropzone) && (
+                <FileDropzone
+                  options={{ multiple: false, accept: 'application/json' }}
+                  readAs="readAsText"
+                  onLoad={(result) => {
+                    readAndValidateJWT(result as string);
+                    setIsPasting(false);
+                  }}
+                >
+                  <p style={{ margin: 0, fontSize: `${theme.typography.h4.fontSize}`, textAlign: 'center' }}>
+                    Drop the Google JWT file here
+                    <br />
+                    <br />
+                    <LinkButton fill="outline">Click to browse files</LinkButton>
+                  </p>
+                </FileDropzone>
+              )}
             </div>
           )}
 

--- a/src/components/QueryHeader.tsx
+++ b/src/components/QueryHeader.tsx
@@ -1,6 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 import { EditorField, EditorHeader, EditorMode, EditorRow, FlexItem, InlineSelect, Space } from '@grafana/experimental';
-import { Button, InlineSwitch, RadioButtonGroup, Tooltip } from '@grafana/ui';
+import { Button, InlineField, InlineSwitch, RadioButtonGroup, Select, Tooltip } from '@grafana/ui';
 import { BigQueryAPI } from 'api';
 import React, { useCallback, useState } from 'react';
 import { useCopyToClipboard } from 'react-use';
@@ -9,6 +9,7 @@ import { DEFAULT_REGION, PROCESSING_LOCATIONS, QUERY_FORMAT_OPTIONS } from '../c
 import { BigQueryQueryNG, QueryFormat, QueryRowFilter, QueryWithDefaults } from '../types';
 import { ConfirmModal } from './ConfirmModal';
 import { DatasetSelector } from './DatasetSelector';
+import { ErrorBoundary } from './ErrorBoundary';
 import { ProjectSelector } from './ProjectSelector';
 import { TableSelector } from './TableSelector';
 
@@ -106,24 +107,53 @@ export function QueryHeader({
   return (
     <>
       <EditorHeader>
-        <InlineSelect
-          label="Processing location"
-          value={location}
-          placeholder="Select location"
-          allowCustomValue
-          menuShouldPortal
-          onChange={({ value }) => value && onChange({ ...query, location: value || DEFAULT_REGION })}
-          options={PROCESSING_LOCATIONS}
-        />
+        {/* Backward compatibility check. Inline select uses SelectContainer that was added in 8.3 */}
+        <ErrorBoundary
+          fallBackComponent={
+            <InlineField label="Processing location" labelWidth={20}>
+              <Select
+                placeholder="Select location"
+                allowCustomValue
+                value={location}
+                onChange={({ value }) => value && onChange({ ...query, location: value || DEFAULT_REGION })}
+                options={PROCESSING_LOCATIONS}
+              />
+            </InlineField>
+          }
+        >
+          <InlineSelect
+            label="Processing location"
+            value={location}
+            placeholder="Select location"
+            allowCustomValue
+            menuShouldPortal
+            onChange={({ value }) => value && onChange({ ...query, location: value || DEFAULT_REGION })}
+            options={PROCESSING_LOCATIONS}
+          />
+        </ErrorBoundary>
 
-        <InlineSelect
-          label="Format"
-          value={query.format}
-          placeholder="Select format"
-          menuShouldPortal
-          onChange={onFormatChange}
-          options={QUERY_FORMAT_OPTIONS}
-        />
+        {/* Backward compatibility check. Inline select uses SelectContainer that was added in 8.3 */}
+        <ErrorBoundary
+          fallBackComponent={
+            <InlineField label="Format" labelWidth={15}>
+              <Select
+                placeholder="Select format"
+                value={query.format}
+                onChange={onFormatChange}
+                options={QUERY_FORMAT_OPTIONS}
+              />
+            </InlineField>
+          }
+        >
+          <InlineSelect
+            label="Format"
+            value={query.format}
+            placeholder="Select format"
+            menuShouldPortal
+            onChange={onFormatChange}
+            options={QUERY_FORMAT_OPTIONS}
+          />
+        </ErrorBoundary>
 
         {editorMode === EditorMode.Builder && (
           <>

--- a/src/components/TableSelector.tsx
+++ b/src/components/TableSelector.tsx
@@ -1,7 +1,8 @@
-import { SelectableValue, toOption } from '@grafana/data';
+import { SelectableValue } from '@grafana/data';
 import { Select } from '@grafana/ui';
 import React from 'react';
 import { useAsync } from 'react-use';
+import { toOption } from 'utils/data';
 import { QueryWithDefaults, ResourceSelectorProps } from '../types';
 
 interface TableSelectorProps extends ResourceSelectorProps {

--- a/src/components/visual-query-builder/AwesomeQueryBuilder.tsx
+++ b/src/components/visual-query-builder/AwesomeQueryBuilder.tsx
@@ -1,7 +1,8 @@
-import { dateTime, toOption } from '@grafana/data';
+import { dateTime } from '@grafana/data';
 import { Button, DateTimePicker, Input, Select } from '@grafana/ui';
 import React from 'react';
 import { BasicConfig, Config, JsonItem, Settings, Utils, Widgets } from 'react-awesome-query-builder';
+import { toOption } from 'utils/data';
 
 const buttonLabels = {
   add: 'Add',

--- a/src/components/visual-query-builder/SQLGroupByRow.tsx
+++ b/src/components/visual-query-builder/SQLGroupByRow.tsx
@@ -1,9 +1,10 @@
-import { SelectableValue, toOption } from '@grafana/data';
+import { SelectableValue } from '@grafana/data';
 import { AccessoryButton, EditorList, InputGroup } from '@grafana/experimental';
 import { Select } from '@grafana/ui';
 import { QueryEditorGroupByExpression } from 'expressions';
 import React, { useCallback } from 'react';
 import { SQLExpression } from 'types';
+import { toOption } from 'utils/data';
 import { setGroupByField } from 'utils/sql.utils';
 
 interface SQLGroupByRowProps {

--- a/src/components/visual-query-builder/SQLOrderByRow.tsx
+++ b/src/components/visual-query-builder/SQLOrderByRow.tsx
@@ -1,9 +1,10 @@
-import { SelectableValue, toOption } from '@grafana/data';
+import { SelectableValue } from '@grafana/data';
 import { EditorField, InputGroup, Space } from '@grafana/experimental';
 import { Input, RadioButtonGroup, Select } from '@grafana/ui';
 import { uniqueId } from 'lodash';
 import React, { useCallback } from 'react';
 import { SQLExpression } from 'types';
+import { toOption } from 'utils/data';
 import { setPropertyField } from 'utils/sql.utils';
 
 type SQLOrderByRowProps = {

--- a/src/components/visual-query-builder/SQLSelectRow.tsx
+++ b/src/components/visual-query-builder/SQLSelectRow.tsx
@@ -1,10 +1,11 @@
 import { css } from '@emotion/css';
-import { SelectableValue, toOption } from '@grafana/data';
+import { SelectableValue } from '@grafana/data';
 import { EditorField, Stack } from '@grafana/experimental';
 import { Button, Select, useStyles2 } from '@grafana/ui';
 import { QueryEditorExpressionType, QueryEditorFunctionExpression } from 'expressions';
 import { uniqueId } from 'lodash';
 import React, { useCallback } from 'react';
+import { toOption } from 'utils/data';
 import { createFunctionField } from 'utils/sql.utils';
 import { SQLExpression } from '../../types';
 import { BQ_AGGREGATE_FNS } from '../query-editor-raw/bigQueryFunctions';

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -99,7 +99,7 @@ export class BigQueryDatasource extends DataSourceWithBackend<BigQueryQueryNG, B
 
   async testDatasource() {
     const health = await this.callHealthCheck();
-    if (health.status.toLowerCase() === 'error') {
+    if (health.status?.toLowerCase() === 'error') {
       return { status: 'error', message: health.message, details: health.details };
     }
 

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -1,0 +1,5 @@
+import { SelectableValue, toOption as toOptionFromData } from '@grafana/data';
+
+const backWardToOption = (value: string) => ({ label: value, value } as SelectableValue<string>);
+
+export const toOption = toOptionFromData ?? backWardToOption;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,10 +1233,10 @@
     prettier "2.2.1"
     typescript "4.3.4"
 
-"@grafana/experimental@0.0.2-canary.30":
-  version "0.0.2-canary.30"
-  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.30.tgz#e43c8cdf4ea4bb1ef0589aaae3a24320160d01e3"
-  integrity sha512-gWnMBZ4i0Wp01AGq1peCEbgnZlN1khgWtpd6UBkrLnzWeOuXjNp1WZG/3+fKXLjM65ql+bB/fCGg6bTQCgSGTg==
+"@grafana/experimental@0.0.2-canary.31":
+  version "0.0.2-canary.31"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.31.tgz#715d1addf4c89c8c546f1c2ea3064d2aec112578"
+  integrity sha512-imBIxOyoEfwbfs8YsqXWIjFQZYoow+35dB7rth743kJwxsLpjFJfQ/ewX/EOW2VMUYyXNd/BR0yrDnyr0Fcl6w==
   dependencies:
     "@types/uuid" "^8.3.3"
     uuid "^8.3.2"


### PR DESCRIPTION
I tested this with this docker command.

```
  docker run -d \
    -e GF_DEFAULT_APP_MODE=development \
    -e GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-bigquery-datasource \
    -e GF_AUTH_ANONYMOUS_ORG_ROLE=Admin \
    -e GF_AUTH_ANONYMOUS_ENABLED=true \
    -e GF_AUTH_BASIC_ENABLED=false \
    -p 3001:3000 \
    -v ~/GitHub/grafana/plugins/google-bigquery-datasource:/var/lib/grafana/plugins/google-bigquery-datasource \
    grafana/grafana:8.0.0
```

Fixes #121