### PR TITLE
Show correct bar chart error

### DIFF
--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -57,7 +57,7 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
     <>
       <ConfigurationHelp />
 
-      <FieldSet label="Authentication">
+      <FieldSet label="Authentication =)">
         <Field label="Authentication type">
           <RadioButtonGroup
             options={GOOGLE_AUTH_TYPE_OPTIONS}


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes the error with the bar chart displaying the JS error instead of the datasource error.