### PR TITLE
Use client location when configuring query job

### DIFF
--- a/pkg/bigquery/driver/conn.go
+++ b/pkg/bigquery/driver/conn.go
@@ -223,9 +223,7 @@ func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 
 func (c *Conn) queryContext(ctx context.Context, query string, args []driver.Value) (driver.Rows, error) {
 	q := c.client.Query(query)
-
-	// q.DefaultProjectID = c.cfg.Project // allows omitting project in table reference
-	// q.DefaultDatasetID = c.cfg.Dataset // allows omitting dataset in table reference
+	q.Location = c.client.Location
 
 	rowsIterator, err := q.Read(ctx)
 	if err != nil {


### PR DESCRIPTION
Fixes #135 

Since queries are performed via BQ SDK's fast path (preconfigured job) [1],[2], the job's location is not being applied based on the client configuration. Hence we need to manually specify the query processing location as in the proposed change.

[1] https://github.com/googleapis/google-cloud-go/blob/main/bigquery/query.go#L386
[2] https://github.com/googleapis/google-cloud-go/blob/main/bigquery/query.go#L423