### PR TITLE
Minor tweaks to JWT config form

### DIFF
--- a/src/components/ConfigEditor.test.tsx
+++ b/src/components/ConfigEditor.test.tsx
@@ -26,6 +26,7 @@ describe('ConfigEditor', () => {
         options={
           {
             jsonData: {},
+            secureJsonFields: {},
           } as DataSourceSettings<BigQueryOptions, BigQuerySecureJsonData>
         }
         onOptionsChange={() => {}}
@@ -41,6 +42,7 @@ describe('ConfigEditor', () => {
         options={
           {
             jsonData: {},
+            secureJsonFields: {},
           } as DataSourceSettings<BigQueryOptions, BigQuerySecureJsonData>
         }
         onOptionsChange={() => {}}
@@ -56,6 +58,7 @@ describe('ConfigEditor', () => {
         options={
           {
             jsonData: {},
+            secureJsonFields: {},
           } as DataSourceSettings<BigQueryOptions, BigQuerySecureJsonData>
         }
         onOptionsChange={() => {}}
@@ -74,6 +77,7 @@ describe('ConfigEditor', () => {
         defaultOptions={
           {
             jsonData: {},
+            secureJsonFields: {},
           } as DataSourceSettings<BigQueryOptions, BigQuerySecureJsonData>
         }
       >
@@ -127,6 +131,7 @@ describe('ConfigEditor', () => {
         defaultOptions={
           {
             jsonData: {},
+            secureJsonFields: {},
           } as DataSourceSettings<BigQueryOptions, BigQuerySecureJsonData>
         }
       >
@@ -219,6 +224,7 @@ describe('ConfigEditor', () => {
               defaultProject: 'test-project',
               privateKeyPath: 'private/key/path',
             },
+            secureJsonFields: {},
           } as unknown) as DataSourceSettings<BigQueryOptions, BigQuerySecureJsonData>
         }
         onOptionsChange={() => {}}
@@ -245,6 +251,7 @@ describe('ConfigEditor', () => {
               tokenUri: 'https://accounts.google.com/o/oauth2/token',
               defaultProject: 'test-project',
             },
+            secureJsonFields: {},
           } as unknown) as DataSourceSettings<BigQueryOptions, BigQuerySecureJsonData>
         }
         onOptionsChange={onOptionsChangeSpy}
@@ -257,6 +264,7 @@ describe('ConfigEditor', () => {
     expect(onOptionsChangeSpy).toHaveBeenCalledWith({
       jsonData: { authenticationType: GoogleAuthType.GCE },
       secureJsonData: {},
+      secureJsonFields: { privateKey: false },
     });
   });
 });

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -61,6 +61,7 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
     setConfigEditorVisible(false);
     onOptionsChange({
       ...options,
+      secureJsonFields: { ...options.secureJsonFields, privateKey: false },
       secureJsonData: nextSecureJsonData,
       jsonData: nextJsonData,
     });
@@ -88,7 +89,12 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
       {jwtAuth && (
         <FieldSet label="JWT Key Details">
           {configEditorVisible ? (
-            <JWTForm options={options.jsonData} onReset={() => onResetApiKey()} onChange={onJWTFormChange} />
+            <JWTForm
+              options={options.jsonData}
+              hasPrivateKeyConfigured={Boolean(options.secureJsonFields.privateKey)}
+              onReset={() => onResetApiKey()}
+              onChange={onJWTFormChange}
+            />
           ) : (
             <JWTConfigEditor
               showConfigEditor={showConfigEditor}


### PR DESCRIPTION
Brings back a placeholder for a configured private key. There were few changes made in https://github.com/grafana/google-bigquery-datasource/pull/131 that impact the complexity if this PR.