### PR TITLE
Chore: Backend binaries are now compiled with golang 1.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.6
+
+- **Chore** - CI pipeline updated with GO 1.20.4
+
 ## 1.2.5
 
 - **Chore**: Bump go version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.6
 
-- **Chore** - CI pipeline updated with GO 1.20.4
+- **Chore** - Backend binaries are now compiled with golang 1.20.4
 
 ## 1.2.5
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Google BigQuery datasource for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Backend binaries are now compiled with golang 1.20.4