### PR TITLE
add gdrive to the scopes for service accounts.  

### DIFF
--- a/pkg/bigquery/http_client.go
+++ b/pkg/bigquery/http_client.go
@@ -24,6 +24,7 @@ var routes = map[string]routeInfo{
 	bigQueryRoute: {
 		method: "GET",
 		scopes: []string{BigQueryScope,
+			"https://www.googleapis.com/auth/drive",
 			"https://www.googleapis.com/auth/bigquery.insertdata",
 			"https://www.googleapis.com/auth/cloud-platform",
 			"https://www.googleapis.com/auth/cloud-platform.read-only",


### PR DESCRIPTION
This will allow querying google drive backed tables.  

This was actually the existing behavior in the doit plugin (i think from here and this is no longer read: https://github.com/grafana/google-bigquery-datasource/blob/1ec88a0e74971f8fc3795edaf8324337049a58b2/src/plugin.json#L46)

Fixes: https://github.com/grafana/google-bigquery-datasource/issues/154