### PR TITLE
Chore: Bump to v1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.9
+
+- **Chore**: Use SQLDS in every plugin instance.
 ## 1.2.8
 
 - **Fix**: Variable query error because missing refId #180

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Google BigQuery datasource for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
This PR bumps to version 1.2.9 which instantiates SQL DS for every plugin instance.