### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.0
+
+- **Feature:** Add support for PDC.
+
 ## 1.2.9
 
 - **Chore**: Use SQLDS in every plugin instance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "description": "Google BigQuery datasource for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
This PR bumps the version to 1.3.0 and updates the changelog. This release would include changes for PDC