### PR TITLE
[WIP] Revert EditorList modifications

### DIFF
--- a/src/components/query-editor-raw/bigqueryCompletionProvider.ts
+++ b/src/components/query-editor-raw/bigqueryCompletionProvider.ts
@@ -32,7 +32,7 @@ export const getBigQueryCompletionProvider: (args: CompletionProviderGetterArgs)
     resolve: async () => {
       return await getTables.current();
     },
-    parseName: (token: LinkedToken) => {
+    parseName: (token: LinkedToken | null | undefined) => {
       let processedToken = token;
       let tablePath = processedToken?.value ?? '';
 

--- a/src/components/query-editor-raw/bigqueryCompletionProvider.ts
+++ b/src/components/query-editor-raw/bigqueryCompletionProvider.ts
@@ -32,7 +32,7 @@ export const getBigQueryCompletionProvider: (args: CompletionProviderGetterArgs)
     resolve: async () => {
       return await getTables.current();
     },
-    parseName: (token: LinkedToken | null | undefined) => {
+    parseName: (token: LinkedToken) => {
       let processedToken = token;
       let tablePath = processedToken?.value ?? '';
 

--- a/src/components/visual-query-builder/SQLGroupByRow.tsx
+++ b/src/components/visual-query-builder/SQLGroupByRow.tsx
@@ -1,7 +1,7 @@
 import { SelectableValue } from '@grafana/data';
 import { AccessoryButton, EditorList, InputGroup } from '@grafana/experimental';
 import { Select } from '@grafana/ui';
-import { QueryEditorExpressionType, QueryEditorGroupByExpression } from 'expressions';
+import { QueryEditorGroupByExpression } from 'expressions';
 import React, { useCallback } from 'react';
 import { SQLExpression } from 'types';
 import { toOption } from 'utils/data';
@@ -15,15 +15,9 @@ interface SQLGroupByRowProps {
 
 export function SQLGroupByRow({ sql, columns, onSqlChange }: SQLGroupByRowProps) {
   const onGroupByChange = useCallback(
-    (items: unknown[]) => {
+    (item: Array<Partial<QueryEditorGroupByExpression>>) => {
       // As new (empty object) items come in, we need to make sure they have the correct type
-      const cleaned = items.map((v) => {
-        // Narrow the type for item to QueryEditorGroupByExpression
-        if (isQueryEditorGroupByExpression(v)) {
-          return setGroupByField(v.property?.name);
-        }
-        return setGroupByField();
-      });
+      const cleaned = item.map((v) => setGroupByField(v.property?.name));
       const newSql = { ...sql, groupBy: cleaned };
       onSqlChange(newSql);
     },
@@ -43,14 +37,14 @@ export function SQLGroupByRow({ sql, columns, onSqlChange }: SQLGroupByRowProps)
 
 function makeRenderColumn({ options }: { options?: Array<SelectableValue<string>> }) {
   const renderColumn = function (
-    item: unknown,
-    onChangeItem: (item: unknown) => void,
+    item: Partial<QueryEditorGroupByExpression>,
+    onChangeItem: (item: QueryEditorGroupByExpression) => void,
     onDeleteItem: () => void
   ) {
     return (
       <InputGroup>
         <Select
-          value={isQueryEditorGroupByExpression(item) && item.property?.name ? toOption(item.property.name) : null}
+          value={item.property?.name ? toOption(item.property.name) : null}
           aria-label="Group by"
           options={options}
           menuShouldPortal
@@ -61,9 +55,4 @@ function makeRenderColumn({ options }: { options?: Array<SelectableValue<string>
     );
   };
   return renderColumn;
-}
-
-// Type guard for QueryEditorGroupByExpression
-function isQueryEditorGroupByExpression(item: unknown): item is QueryEditorGroupByExpression {
-  return typeof item === 'object' && item != null && 'type' in item && item.type === QueryEditorExpressionType.GroupBy;
 }


### PR DESCRIPTION
This PR is a bit premature but would eventually need to be merged. It reverts most of the changes of https://github.com/grafana/google-bigquery-datasource/pull/175, except the removal of the generic on `EditorList` component.

Context:
The type changes done to experimental regarding the `EditorList` component causes crashes in Grafana, so both the modifications done here and in the actual package need to be reverted. This PR is still WIP as we first need to publish a new version of the experimental package and then return to this PR and update the version here.