### PR TITLE
Add gdrive to the scopes for service accounts

### DIFF
--- a/pkg/bigquery/http_client.go
+++ b/pkg/bigquery/http_client.go
@@ -24,6 +24,7 @@ var routes = map[string]routeInfo{
 	bigQueryRoute: {
 		method: "GET",
 		scopes: []string{BigQueryScope,
+			"https://www.googleapis.com/auth/drive",
 			"https://www.googleapis.com/auth/bigquery.insertdata",
 			"https://www.googleapis.com/auth/cloud-platform",
 			"https://www.googleapis.com/auth/cloud-platform.read-only",


### PR DESCRIPTION
This PR will allow querying google drive backed tables.
Fixes: https://github.com/grafana/google-bigquery-datasource/issues/154

Note this is a duplicate of: https://github.com/grafana/google-bigquery-datasource/pull/189. which has been held up by getting permission to sign the CLA (Contributor Licence agreement). 

