### PR TITLE
add unique switch ids

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -1,5 +1,9 @@
 {
-  "ignorePaths": ["node_modules/**", "src/dashboards/arrays.json", "dist/**"],
+  "ignorePaths": [
+    "node_modules/**",
+    "src/dashboards/arrays.json",
+    "dist/**"
+  ],
   "words": [
     "BIGNUMERIC",
     "BYTEINT",
@@ -53,6 +57,7 @@
     "TINYINT",
     "tokenprovider",
     "typecheck",
+    "uuidv",
     "vectorator"
   ],
   "language": "en-US"

--- a/src/components/QueryHeader.tsx
+++ b/src/components/QueryHeader.tsx
@@ -11,6 +11,7 @@ import { ConfirmModal } from './ConfirmModal';
 import { DatasetSelector } from './DatasetSelector';
 import { ProjectSelector } from './ProjectSelector';
 import { TableSelector } from './TableSelector';
+import { v4 as uuidv4 } from 'uuid';
 
 interface QueryHeaderProps {
   query: QueryWithDefaults;
@@ -159,7 +160,7 @@ export function QueryHeader({
         {editorMode === EditorMode.Builder && (
           <>
             <InlineSwitch
-              id="bq-filter"
+              id={`bq-filter-${uuidv4()}}`}
               label="Filter"
               transparent={true}
               showLabel={true}
@@ -171,7 +172,7 @@ export function QueryHeader({
             />
 
             <InlineSwitch
-              id="bq-group"
+              id={`bq-group-${uuidv4()}}`}
               label="Group"
               transparent={true}
               showLabel={true}
@@ -183,7 +184,7 @@ export function QueryHeader({
             />
 
             <InlineSwitch
-              id="bq-order"
+              id={`bq-order-${uuidv4()}}`}
               label="Order"
               transparent={true}
               showLabel={true}
@@ -195,7 +196,7 @@ export function QueryHeader({
             />
 
             <InlineSwitch
-              id="bq-preview"
+              id={`bq-preview-${uuidv4()}}`}
               label="Preview"
               transparent={true}
               showLabel={true}


### PR DESCRIPTION
this issue was fixed for core datasources, however bigquery doensn't share that component
fixes: https://github.com/grafana/grafana/issues/74086