### PR TITLE
Do not pass a default location to BQ when none is specified by the user

### DIFF
--- a/pkg/bigquery/api/api.go
+++ b/pkg/bigquery/api/api.go
@@ -90,6 +90,9 @@ func (a *API) GetTableSchema(ctx context.Context, dataset, table string) (*types
 }
 
 func (a *API) SetLocation(location string) {
+	if location == "Unspecified" {
+		location = ""
+	}
 	a.Client.Location = location
 }
 

--- a/pkg/bigquery/settings.go
+++ b/pkg/bigquery/settings.go
@@ -36,7 +36,7 @@ func loadSettings(config *backend.DataSourceInstanceSettings) (types.BigQuerySet
 	settings.Updated = config.Updated
 
 	if settings.ProcessingLocation == "" {
-		settings.ProcessingLocation = "US"
+		settings.ProcessingLocation = "Unspecified"
 	}
 
 	return settings, nil

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -52,7 +52,7 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
         >
           <Select
             className="width-30"
-            placeholder="Default US"
+            placeholder="Default Unspecified"
             value={jsonData.processingLocation || ''}
             options={PROCESSING_LOCATIONS}
             onChange={onUpdateDatasourceJsonDataOptionSelect(props, 'processingLocation')}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,9 +6,11 @@ export const QUERY_FORMAT_OPTIONS = [
   { label: 'Table', value: QueryFormat.Table },
 ];
 
-export const DEFAULT_REGION = 'US';
+export const DEFAULT_REGION = 'Unspecified';
 
 export const PROCESSING_LOCATIONS: Array<SelectableValue<string>> = [
+  { label: 'Unspecified', value: DEFAULT_REGION },
+
   // Multi-regional locations
   { label: 'United States (US)', value: 'US' },
   { label: 'European Union (EU)', value: 'EU' },


### PR DESCRIPTION
See #232 for rationale

Implementation wise - might be more appropriate to use `""` rather than `"Unspecified"` but this caused me some issues on the front-end side, probably something with how falsy values are treated in JS. 