### PR TITLE
Hide project from ProjectSelector when it is not returned in getProjects

### DIFF
--- a/src/components/ProjectSelector.tsx
+++ b/src/components/ProjectSelector.tsx
@@ -63,8 +63,8 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({ apiClient, val
       <EditorField label="Project" width={25} error={getErrorMessage()} invalid={!!state.error}>
         <Select
           aria-label="Project selector"
-          value={value}
-          options={state.value || [{ label: value, value }]}
+          value={state.loading ? null : value}
+          options={state.loading ? [] : state.value || [{ label: value, value }]}
           onChange={onChange}
           isLoading={state.loading}
           menuShouldPortal={true}

--- a/src/components/QueryHeader.tsx
+++ b/src/components/QueryHeader.tsx
@@ -243,7 +243,7 @@ export function QueryHeader({
           <Space v={0.5} />
 
           <EditorRow>
-            <ProjectSelector apiClient={apiClient} value={query.project} onChange={onProjectChange} />
+            <ProjectSelector apiClient={apiClient} value={query.project} onChange={onProjectChange} applyDefault />
 
             <EditorField label="Dataset" width={25}>
               <DatasetSelector


### PR DESCRIPTION
Allows implementing #230 and solves a UI edge case

Currently in the front-end, if the project defined as `defaultProject` is not returned by the `apiClient.getProjects` call,
it will appear in the project picker momentarily, until the initial load load succeeds. At which point it will no longer in the selector's options if you open the dropdown (yet it still appears as the placeholder/selected value)

Such scenario is possible when we manually create a GCP role for `defaultProject` that contains `bigquery.jobs.create` permission, but does not include resourcemanager permissions that make this project visible to the `getProjects` call. Per the discussion at #227, this can be a way of achieving #230 - we may want to hide the project on purpose despite still using it for running query jobs, as it does not contain any queryable datasets.


The fix is fairly simple - there's already an `applyDefault` prop that does most of the work, yet wasn't set on this component
I've also hidden the `value` from displaying in the value/options of the selector while loading.

Flow is as follows:
1. Initially, `value` prop is the `defaultProject` 
2. On initialization of the project selector component, it starts querying `getProjects` from the plugin backend.
3. When the query finishes, it populates the possible options.
4. Now, with the `applyDefault` prop, it will check if the current `value` appears in the list of projects, and if it doesn't, it will select the first project that does appear.



