### PR TITLE
Enhancement: Variable Support for Dynamic Dashboard Loading with Multiple BigQuery Datasources

### DIFF
--- a/src/components/DatasetSelector.tsx
+++ b/src/components/DatasetSelector.tsx
@@ -25,8 +25,12 @@ export const DatasetSelector: React.FC<DatasetSelectorProps> = ({
   applyDefault,
 }) => {
   const state = useAsync(async () => {
-    const datasets = await apiClient.getDatasets(location, project);
-    return datasets.map(toOption);
+    try {
+      const datasets = await apiClient.getDatasets(location, project);
+      return datasets.map((dataset) => ({ label: dataset, value: dataset }));
+    } catch (error) {
+      return [];
+    }
   }, [location, project]);
 
   useEffect(() => {
@@ -47,13 +51,13 @@ export const DatasetSelector: React.FC<DatasetSelectorProps> = ({
       }
     }
   }, [state.value, value, location, applyDefault, onChange]);
-
   return (
     <Select
       className={className}
       aria-label="Dataset selector"
       value={value}
-      options={state.value}
+      allowCustomValue
+      options={state.value || [{ label: value, value }]}
       onChange={onChange}
       disabled={disabled}
       isLoading={state.loading}

--- a/src/components/ProjectSelector.tsx
+++ b/src/components/ProjectSelector.tsx
@@ -66,6 +66,7 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({ apiClient, val
           value={value}
           options={state.value || [{ label: value, value }]}
           onChange={onChange}
+          allowCustomValue
           isLoading={state.loading}
           menuShouldPortal={true}
         />

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -68,7 +68,6 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery, range, sh
   if (apiLoading || apiError || !apiClient) {
     return null;
   }
-
   return (
     <>
       <QueryHeader

--- a/src/components/QueryHeader.tsx
+++ b/src/components/QueryHeader.tsx
@@ -144,7 +144,7 @@ export function QueryHeader({
           placeholder="Select location"
           allowCustomValue
           menuShouldPortal
-          onChange={({ value }) => value && onChange({ ...query, location: value })}
+          onChange={({ value }) => value != null && onChange({ ...query, location: value || '' })}
           options={PROCESSING_LOCATIONS}
         />
 

--- a/src/components/QueryHeader.tsx
+++ b/src/components/QueryHeader.tsx
@@ -144,7 +144,7 @@ export function QueryHeader({
           placeholder="Select location"
           allowCustomValue
           menuShouldPortal
-          onChange={({ value }) => value && onChange({ ...query, location: value || DEFAULT_REGION })}
+          onChange={({ value }) => value && onChange({ ...query, location: value })}
           options={PROCESSING_LOCATIONS}
         />
 

--- a/src/components/TableSelector.tsx
+++ b/src/components/TableSelector.tsx
@@ -17,7 +17,7 @@ export const TableSelector: React.FC<TableSelectorProps> = ({ apiClient, query, 
       return [];
     }
     const tables = await apiClient.getTables(query);
-    return tables.map(toOption);
+    return tables.map((table) => ({ label: table, value: table })); // Adjust label and value properties based on table structure
   }, [query]);
 
   return (
@@ -26,7 +26,8 @@ export const TableSelector: React.FC<TableSelectorProps> = ({ apiClient, query, 
       disabled={state.loading}
       aria-label="Table selector"
       value={value}
-      options={state.value}
+      allowCustomValue
+      options={state.value || [{ label: value, value }]}
       onChange={onChange}
       isLoading={state.loading}
       menuShouldPortal={true}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,7 @@ export const DEFAULT_REGION = 'US';
 
 export const PROCESSING_LOCATIONS: Array<SelectableValue<string>> = [
   // Multi-regional locations
+  { label: 'Default', value: 'UD' },
   { label: 'United States (US)', value: 'US' },
   { label: 'European Union (EU)', value: 'EU' },
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -122,7 +122,6 @@ export class BigQueryDatasource extends DataSourceWithBackend<BigQueryQueryNG, B
             : this.jsonData.processingLocation!,
       },
     };
-    console.log(result);
     return result;
   }
 }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -103,21 +103,26 @@ export class BigQueryDatasource extends DataSourceWithBackend<BigQueryQueryNG, B
 
   applyTemplateVariables(queryModel: BigQueryQueryNG, scopedVars: ScopedVars): QueryModel {
     const interpolatedSql = getTemplateSrv().replace(queryModel.rawSql, scopedVars, interpolateVariable);
-
     const result = {
       refId: queryModel.refId,
       hide: queryModel.hide,
       key: queryModel.key,
       queryType: queryModel.queryType,
-      datasource: queryModel.datasource,
+      datasource: this.getRef(),
       rawSql: interpolatedSql,
       format: queryModel.format,
       connectionArgs: {
         dataset: queryModel.dataset!,
         table: queryModel.table!,
-        location: queryModel.location!,
+        // eslint-disable-next-line prettier/prettier
+        location: queryModel.location !== 'UD' && queryModel.location !== undefined  // eslint-disable-next-line prettier/prettier
+          ? queryModel.location  // eslint-disable-next-line prettier/prettier
+          : queryModel.location === undefined
+            ? DEFAULT_REGION
+            : this.jsonData.processingLocation!,
       },
     };
+    console.log(result);
     return result;
   }
 }


### PR DESCRIPTION
This pull request introduces two key enhancements:

**Variable Support for Inputs:**

Users can now utilize Grafana dashboard variables to specify projects, datasets, and tables. This enables dynamic customization of dashboard content based on user-defined variables, enhancing flexibility and adaptability.

**Dynamic Processing Locations:**

The addition of a "Default" processing location option allows users to select the execution location for queries. When "Default" is chosen, the system automatically uses the default location of the selected BigQuery datasource. This feature streamlines query execution, improving efficiency and usability for users managing multiple datasources.

![image](https://github.com/grafana/google-bigquery-datasource/assets/42514824/0a7e7c19-1e34-435d-a9c6-c408fc915b4d)

   