### PR TITLE
Feature: Limit billable bytes per query

### DIFF
--- a/pkg/bigquery/driver/conn.go
+++ b/pkg/bigquery/driver/conn.go
@@ -124,6 +124,11 @@ func (c *Conn) execContext(ctx context.Context, query string, args []driver.Valu
 	q := c.client.Query(query)
 
 	q.QueryConfig.Labels = c.headersAsLabels()
+
+	if c.cfg.MaxBillableBytes > 0 {
+		q.QueryConfig.MaxBytesBilled = c.cfg.MaxBillableBytes
+	}
+
 	// q.DefaultProjectID = c.cfg.Project // allows omitting project in table reference
 	// q.DefaultDatasetID = c.cfg.Dataset // allows omitting dataset in table reference
 
@@ -227,6 +232,10 @@ func (c *Conn) queryContext(ctx context.Context, query string, args []driver.Val
 	q.Location = c.client.Location
 
 	q.QueryConfig.Labels = c.headersAsLabels()
+
+	if c.cfg.MaxBillableBytes > 0 {
+		q.QueryConfig.MaxBytesBilled = c.cfg.MaxBillableBytes
+	}
 
 	rowsIterator, err := q.Read(ctx)
 	if err != nil {

--- a/pkg/bigquery/driver/conn.go
+++ b/pkg/bigquery/driver/conn.go
@@ -125,8 +125,8 @@ func (c *Conn) execContext(ctx context.Context, query string, args []driver.Valu
 
 	q.QueryConfig.Labels = c.headersAsLabels()
 
-	if c.cfg.MaxBillableBytes > 0 {
-		q.QueryConfig.MaxBytesBilled = c.cfg.MaxBillableBytes
+	if c.cfg.MaxBytesBilled > 0 {
+		q.QueryConfig.MaxBytesBilled = c.cfg.MaxBytesBilled
 	}
 
 	// q.DefaultProjectID = c.cfg.Project // allows omitting project in table reference
@@ -233,8 +233,8 @@ func (c *Conn) queryContext(ctx context.Context, query string, args []driver.Val
 
 	q.QueryConfig.Labels = c.headersAsLabels()
 
-	if c.cfg.MaxBillableBytes > 0 {
-		q.QueryConfig.MaxBytesBilled = c.cfg.MaxBillableBytes
+	if c.cfg.MaxBytesBilled > 0 {
+		q.QueryConfig.MaxBytesBilled = c.cfg.MaxBytesBilled
 	}
 
 	rowsIterator, err := q.Read(ctx)

--- a/pkg/bigquery/settings.go
+++ b/pkg/bigquery/settings.go
@@ -43,6 +43,7 @@ func getConnectionSettings(settings types.BigQuerySettings, queryArgs *Connectio
 		Project:            settings.DefaultProject,
 		Location:           settings.ProcessingLocation,
 		AuthenticationType: settings.AuthenticationType,
+		MaxBillableBytes:   settings.MaxBillableBytes,
 	}
 
 	// We want to set the location to empty string only if query args are set

--- a/pkg/bigquery/settings.go
+++ b/pkg/bigquery/settings.go
@@ -43,7 +43,7 @@ func getConnectionSettings(settings types.BigQuerySettings, queryArgs *Connectio
 		Project:            settings.DefaultProject,
 		Location:           settings.ProcessingLocation,
 		AuthenticationType: settings.AuthenticationType,
-		MaxBillableBytes:   settings.MaxBillableBytes,
+		MaxBytesBilled:   settings.MaxBytesBilled,
 	}
 
 	// We want to set the location to empty string only if query args are set

--- a/pkg/bigquery/types/types.go
+++ b/pkg/bigquery/types/types.go
@@ -14,7 +14,7 @@ type BigQuerySettings struct {
 	TokenUri           string `json:"tokenUri"`
 	QueryPriority      string `json:"queryPriority"`
 	ProcessingLocation string `json:"processingLocation"`
-	MaxBillableBytes   int64  `json:"maxBillableBytes,omitempty"`
+	MaxBytesBilled	   int64  `json:"MaxBytesBilled,omitempty"`
 	Updated            time.Time
 	AuthenticationType string `json:"authenticationType"`
 	PrivateKeyPath     string `json:"privateKeyPath"`
@@ -29,7 +29,7 @@ type ConnectionSettings struct {
 	Project            string
 	Dataset            string
 	Headers            map[string][]string
-	MaxBillableBytes   int64
+	MaxBytesBilled	   int64
 }
 type TableFieldSchema struct {
 	Name        string       `json:"name"`

--- a/pkg/bigquery/types/types.go
+++ b/pkg/bigquery/types/types.go
@@ -14,6 +14,7 @@ type BigQuerySettings struct {
 	TokenUri           string `json:"tokenUri"`
 	QueryPriority      string `json:"queryPriority"`
 	ProcessingLocation string `json:"processingLocation"`
+	MaxBillableBytes   int64  `json:"maxBillableBytes,omitempty"`
 	Updated            time.Time
 	AuthenticationType string `json:"authenticationType"`
 	PrivateKeyPath     string `json:"privateKeyPath"`
@@ -28,6 +29,7 @@ type ConnectionSettings struct {
 	Project            string
 	Dataset            string
 	Headers            map[string][]string
+	MaxBillableBytes   int64
 }
 type TableFieldSchema struct {
 	Name        string       `json:"name"`

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -15,12 +15,12 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
   const { options, onOptionsChange } = props;
   const { jsonData } = options;
 
-  const onMaxBillableBytesChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onMaxBytesBilledChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onOptionsChange({
       ...options,
       jsonData: {
         ...jsonData,
-        maxBillableBytes: Number(event.target.value),
+        MaxBytesBilled: Number(event.target.value),
       },
     });
   };
@@ -70,10 +70,10 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
           />
         </Field>
         <Field
-          label="Max billable bytes"
+          label="Max bytes billed"
           description={
             <span>
-              Prevent queries that would process more than this amount of bytes. Read more about max billable bytes{' '}
+              Prevent queries that would process more than this amount of bytes. Read more about max bytes billed{' '}
               <a
                 href="https://cloud.google.com/bigquery/docs/best-practices-costs"
                 rel="noreferrer"
@@ -89,8 +89,8 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
             className="width-30"
             placeholder="Optional, example 5242880"
             type={'number'}
-            value={jsonData.maxBillableBytes || ''}
-            onChange={onMaxBillableBytesChange}
+            value={jsonData.MaxBytesBilled || ''}
+            onChange={onMaxBytesBilledChange}
           />
         </Field>
 

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,7 +1,7 @@
 import { DataSourcePluginOptionsEditorProps, onUpdateDatasourceJsonDataOptionSelect } from '@grafana/data';
 import { AuthConfig, GOOGLE_AUTH_TYPE_OPTIONS } from '@grafana/google-sdk';
 import { config } from '@grafana/runtime';
-import { Field, SecureSocksProxySettings, Select } from '@grafana/ui';
+import { Field, Input, SecureSocksProxySettings, Select } from '@grafana/ui';
 import React from 'react';
 import { PROCESSING_LOCATIONS } from '../constants';
 import { BigQueryOptions, BigQuerySecureJsonData } from '../types';
@@ -14,6 +14,16 @@ export type BigQueryConfigEditorProps = DataSourcePluginOptionsEditorProps<BigQu
 export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props) => {
   const { options, onOptionsChange } = props;
   const { jsonData } = options;
+
+  const onMaxBillableBytesChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...jsonData,
+        maxBillableBytes: Number(event.target.value),
+      },
+    });
+  };
 
   return (
     <>
@@ -57,6 +67,30 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
             options={PROCESSING_LOCATIONS}
             onChange={onUpdateDatasourceJsonDataOptionSelect(props, 'processingLocation')}
             menuShouldPortal={true}
+          />
+        </Field>
+        <Field
+          label="Max billable bytes"
+          description={
+            <span>
+              Prevent queries that would process more than this amount of bytes. Read more about max billable bytes{' '}
+              <a
+                href="https://cloud.google.com/bigquery/docs/best-practices-costs"
+                rel="noreferrer"
+                className="external-link"
+                target="_blank"
+              >
+                here
+              </a>
+            </span>
+          }
+        >
+          <Input
+            className="width-30"
+            placeholder="Optional, example 5242880"
+            type={'number'}
+            value={jsonData.maxBillableBytes || ''}
+            onChange={onMaxBillableBytesChange}
           />
         </Field>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface BigQueryOptions extends DataSourceOptions {
   processingLocation?: string;
   queryPriority?: QueryPriority;
   enableSecureSocksProxy?: boolean;
-  maxBillableBytes?: number;
+  maxBytesBilled?: number;
 }
 
 export interface BigQuerySecureJsonData extends DataSourceSecureJsonData {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface BigQueryOptions extends DataSourceOptions {
   processingLocation?: string;
   queryPriority?: QueryPriority;
   enableSecureSocksProxy?: boolean;
+  maxBillableBytes?: number;
 }
 
 export interface BigQuerySecureJsonData extends DataSourceSecureJsonData {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/doitintl/bigquery-grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If the PR is unfinished, mark it as a draft PR.
4. Rebase your PR if it gets out of sync with master
-->

**What this PR does / why we need it**:
As an admin, I may want to control the cost of my query spend. With the BigQuery client this can be done by specifying the `MaxBytesBilled` on the QueryConfig. 


This is a split from this [PR](https://github.com/grafana/google-bigquery-datasource/pull/245) by @abannachGrafana.

## Description

This PR adds an configuration field to the datasource:

- `maxBillableBytes` : Applied to the queryconfig on the backend to prevent large queries from running

<img width="619" alt="Screenshot 2024-05-08 at 2 46 06 PM" src="https://github.com/grafana/google-bigquery-datasource/assets/6499180/a98d0774-d618-4696-b62b-2b6af9d3e6b6">
<img width="708" alt="Screenshot 2024-05-08 at 2 47 20 PM" src="https://github.com/grafana/google-bigquery-datasource/assets/6499180/46b7a0c7-cb62-4667-8808-6de4f71cb3fc">
<img width="1210" alt="Screenshot 2024-05-08 at 2 47 37 PM" src="https://github.com/grafana/google-bigquery-datasource/assets/6499180/41d0abfe-3d2f-46f3-af25-4697983ea0da">
<img width="1379" alt="Screenshot 2024-05-08 at 2 48 03 PM" src="https://github.com/grafana/google-bigquery-datasource/assets/6499180/955d8771-d774-4e70-9267-bbf2bdca823b">

