### PR TITLE
Amend backend logs to have correct parameters

### DIFF
--- a/pkg/bigquery/driver/conn.go
+++ b/pkg/bigquery/driver/conn.go
@@ -90,7 +90,7 @@ func prepareQuery(query string, args []driver.Value) (out string, err error) {
 					query = strings.Replace(query, "?", fmt.Sprintf("FROM_BASE64('%s')", data64), 1)
 				}
 			default:
-				log.DefaultLogger.Info(fmt.Sprintf("unknown type: %s", reflect.TypeOf(value).String()))
+				log.DefaultLogger.Warn(fmt.Sprintf("Unknown query arg type: %s", reflect.TypeOf(value).String()))
 				query = strings.Replace(query, "?", fmt.Sprintf("'%s'", value), 1)
 			}
 

--- a/pkg/bigquery/driver/conn.go
+++ b/pkg/bigquery/driver/conn.go
@@ -90,7 +90,7 @@ func prepareQuery(query string, args []driver.Value) (out string, err error) {
 					query = strings.Replace(query, "?", fmt.Sprintf("FROM_BASE64('%s')", data64), 1)
 				}
 			default:
-				log.DefaultLogger.Info("unknown type: %s", reflect.TypeOf(value).String())
+				log.DefaultLogger.Info(fmt.Sprintf("unknown type: %s", reflect.TypeOf(value).String()))
 				query = strings.Replace(query, "?", fmt.Sprintf("'%s'", value), 1)
 			}
 
@@ -204,7 +204,7 @@ func (c *Conn) Ping(ctx context.Context) (err error) {
 		return
 	}
 
-	log.DefaultLogger.Info("Successful Ping", job.LastStatus().State)
+	log.DefaultLogger.Info("Successful Ping", "status", job.LastStatus().State)
 	return
 }
 

--- a/pkg/bigquery/driver/stmt.go
+++ b/pkg/bigquery/driver/stmt.go
@@ -26,7 +26,7 @@ func (s *stmt) NumInput() int {
 
 // Deprecated: Drivers should implement StmtExecContext instead (or additionally).
 func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
-	log.DefaultLogger.Debug("Got stmt.Exec", s.query)
+	log.DefaultLogger.Debug("Got stmt.Exec", "query", s.query)
 	return s.c.Exec(s.query, args)
 }
 
@@ -36,7 +36,7 @@ func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (drive
 
 // Deprecated: Drivers should implement StmtQueryContext instead (or additionally).
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
-	log.DefaultLogger.Debug("Got stmt.Query", s.query)
+	log.DefaultLogger.Debug("Got stmt.Query", "query", s.query)
 	return s.c.Query(s.query, args)
 }
 


### PR DESCRIPTION
I noticed that some logs were badly formatted as the params are expected as pairs.