### PR TITLE
docs: removed macros that do not work in alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,10 @@ FROM `project.dataset.table`
 WHERE $__timeFilter(time_column)
 ```
 
-| Macro example                          | Description                                                                                                                                      |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| _$\_\_timeFilter(timeColumn)_          | Will be replaced by a time range filter using the specified name.                                                                                |
-| _$\_\_timeGroup(timeColumn,interval)_  | Will be replaced by an expression usable in the GROUP BY clause.                                                                                 |
-| _$\_\_from_ or _$\_\_to_               | Will be replaced by a Unix millisecond representation of the time filter start or end time. For example, `timestamp_millis($__to)`               |
-| _${\_\_from:date}_ or _${\_\_to:date}_ | Will be replaced by a date (ISO 8601/RFC 3339) representation of the time filter start or end time. For example, `SELECT DATE('${__from:date}')` |
+| Macro example                         | Description                                                       |
+| ------------------------------------- | ----------------------------------------------------------------- |
+| _$\_\_timeFilter(timeColumn)_         | Will be replaced by a time range filter using the specified name. |
+| _$\_\_timeGroup(timeColumn,interval)_ | Will be replaced by an expression usable in the GROUP BY clause.  |
 
 ### Templates and variables
 


### PR DESCRIPTION
our current documentation claims tha the macros `$__from` and `$__to` works with bigquery.
this is only true in the dashboard&explore, where these are interpolated by generic grafana javascript code.
these do not work in alerting. this confuses our users who try to use this in alerting.

i decided to simply remove them from the documentation for now.
we may decide to implement them in the backend code later, but that's a separate topic.