### PR TITLE
Make icons consistent with other sql datasources

### DIFF
--- a/src/components/query-editor-raw/QueryToolbox.tsx
+++ b/src/components/query-editor-raw/QueryToolbox.tsx
@@ -73,7 +73,7 @@ export function QueryToolbox({ showTools, onFormatCode, onExpand, isExpanded, ..
             {onExpand && (
               <IconButton
                 onClick={() => onExpand(!isExpanded)}
-                name={isExpanded ? 'angle-up' : 'angle-down'}
+                name={isExpanded ? 'angle-double-up' : 'angle-double-down'}
                 size="xs"
                 tooltip={isExpanded ? 'Collapse editor' : 'Expand editor'}
               />

--- a/src/components/query-editor-raw/QueryToolbox.tsx
+++ b/src/components/query-editor-raw/QueryToolbox.tsx
@@ -73,7 +73,7 @@ export function QueryToolbox({ showTools, onFormatCode, onExpand, isExpanded, ..
             {onExpand && (
               <IconButton
                 onClick={() => onExpand(!isExpanded)}
-                name={isExpanded ? 'compress-arrows' : ('expand-arrows-alt' as any)}
+                name={isExpanded ? 'angle-up' : 'angle-down'}
                 size="xs"
                 tooltip={isExpanded ? 'Collapse editor' : 'Expand editor'}
               />


### PR DESCRIPTION
due to a change in grafana, the following icons `compress-arrows` `expand-arrows-alt` cannot be used because they are not listed in the [availableIconsIndex](https://github.com/grafana/grafana/blob/4fef6ff30d683073f0f2e4c10ac039970197446d/packages/grafana-data/src/types/icon.ts#L1).

while this could be solved by added them to the index, it makes sense to change the icons and be consistent with the other SQL based datasources.