### PR TITLE
better timegroup-macro handling for sub-second intervals

### DIFF
--- a/pkg/bigquery/macros.go
+++ b/pkg/bigquery/macros.go
@@ -46,7 +46,7 @@ func macroTimeGroup(query *sqlds.Query, args []string) (string, error) {
 
 	}
 
-	return fmt.Sprintf("TIMESTAMP_SECONDS(DIV(UNIX_SECONDS(%s), %v) * %v)", timeVar, interval.Seconds(), interval.Seconds()), nil
+	return fmt.Sprintf("TIMESTAMP_MILLIS(DIV(UNIX_MILLIS(%s), %v) * %v)", timeVar, interval.Milliseconds(), interval.Milliseconds()), nil
 }
 
 var macros = map[string]sqlds.MacroFunc{

--- a/pkg/bigquery/macros_test.go
+++ b/pkg/bigquery/macros_test.go
@@ -21,7 +21,7 @@ func Test_macros(t *testing.T) {
 			"timeGroup",
 			&sqlds.Query{},
 			[]string{"created_at", "1w"},
-			"TIMESTAMP_SECONDS(DIV(UNIX_SECONDS(created_at), 604800) * 604800)",
+			"TIMESTAMP_MILLIS(DIV(UNIX_MILLIS(created_at), 604800000) * 604800000)",
 			nil,
 		},
 		{
@@ -29,7 +29,7 @@ func Test_macros(t *testing.T) {
 			"timeGroup",
 			&sqlds.Query{},
 			[]string{"created_at", "1d"},
-			"TIMESTAMP_SECONDS(DIV(UNIX_SECONDS(created_at), 86400) * 86400)",
+			"TIMESTAMP_MILLIS(DIV(UNIX_MILLIS(created_at), 86400000) * 86400000)",
 			nil,
 		},
 		{


### PR DESCRIPTION
(fixes https://github.com/grafana/google-bigquery-datasource/issues/257)

the `$__timeGroup(col, '5s')` macro creates roughly this:  `TIMESTAMP_SECONDS(DIV(UNIX_SECONDS(col), 5) * 5)`

this works fine, but if the interval is smaller than `1second`, for example 50 milliseconds, it becomes this:
`TIMESTAMP_SECONDS(DIV(UNIX_SECONDS(col), 0.05) * 0.05)`.

the problem is the `DIV(.... , 0.05)` part. it does not work with non-integer values.

the solution is to switch from seconds to milliseconds. it's what this PR does. (thanks @MatinF for looking into this!)