### PR TITLE
prepare release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
+## 1.7.0
+
+- **Feature**: Allow specifying Max Billable Bytes (#254)
+- **Fix**: Handle sub-second intervals in the timeGroup macro (#262)
+- **Fix**: Fixed log line formatting (#255)
+- **Fix**: Make editor labels clickable (#256)
+- **Fix**: Update docs to list correct macros (#259)
+- **Chore**: Update dependencies (#264)
+- **Chore**: Consistent icons (#261)
+
 ## 1.6.1
+
 - **Chore**: Update dependencies
 
 ## 1.6.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Google BigQuery datasource for Grafana",
   "license": "Apache-2.0",
   "author": "Grafana Labs <team@grafana.com> (https://grafana.com)",


### PR DESCRIPTION
we have many unreleased changes, we should release them.

i incremented the minor-version because we have a new feature in this release.