### PR TITLE
ConfigEditor: Update MaxBytesBilled type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface BigQueryOptions extends DataSourceOptions {
   processingLocation?: string;
   queryPriority?: QueryPriority;
   enableSecureSocksProxy?: boolean;
-  maxBytesBilled?: number;
+  MaxBytesBilled?: number;
 }
 
 export interface BigQuerySecureJsonData extends DataSourceSecureJsonData {}


### PR DESCRIPTION
Fix type error from incorrectly set type `maxBytesBilled `-> `MaxBytesBilled`. As we already used uppercased `MaxBytesBilled`, I updated type. 

Now:
<img width="767" alt="image" src="https://github.com/grafana/google-bigquery-datasource/assets/30407135/2e53e359-595e-44c1-a22c-4798a5dc2c9b">

Before: 
<img width="735" alt="image" src="https://github.com/grafana/google-bigquery-datasource/assets/30407135/689f6439-5422-4356-b22c-e2663a8e487a">
