### PR TITLE
Chore: Add logging for custom endpoint URL

### DIFF
--- a/pkg/bigquery/datasource.go
+++ b/pkg/bigquery/datasource.go
@@ -144,6 +144,7 @@ func (s *BigQueryDatasource) Connect(ctx context.Context, config backend.DataSou
 
 		options := []option.ClientOption{option.WithHTTPClient(client)}
 		if settings.ServiceEndpoint != "" {
+			log.DefaultLogger.Debug("Using custom service endpoint URL", "url", settings.ServiceEndpoint)
 			options = append(options, option.WithEndpoint(settings.ServiceEndpoint))
 		}
 


### PR DESCRIPTION
In https://github.com/grafana/google-bigquery-datasource/pull/266 we've added support for Custom API service endpoint. This PR adds logging for it. 