### PR TITLE
Bump dependencies for version 1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.9.2
+
+- **Chore**: Bump path-to-regexp from 1.8.0 to 1.9.0 (#296)
+- **Chore**: Bump github.com/grafana/grafana-plugin-sdk-go from 0.245.0 to 0.250.0 (#297)
+- **Chore**: Bump dompurify from 3.1.0 to 3.1.6 (#298)
+
 ## 1.9.1
 
 - **Chore**: Update `github.com/grafana/grafana-plugin-sdk-go` to v0.245.0 (#293)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Google BigQuery datasource for Grafana",
   "license": "Apache-2.0",
   "author": "Grafana Labs <team@grafana.com> (https://grafana.com)",


### PR DESCRIPTION
This pull request includes updates to the dependencies of the project. The following dependencies have been bumped: `path-to-regexp` from 1.8.0 to 1.9.0, `github.com/grafana/grafana-plugin-sdk-go` from 0.245.0 to 0.250.0, and `dompurify` from 3.1.0 to 3.1.6. These updates ensure that the project is using the latest versions of these dependencies.