### PR TITLE
Add support for service account impersonation

### DIFF
--- a/pkg/bigquery/types/types.go
+++ b/pkg/bigquery/types/types.go
@@ -7,18 +7,20 @@ import (
 )
 
 type BigQuerySettings struct {
-	DatasourceId       int64  `json:"datasourceId"`
-	ClientEmail        string `json:"clientEmail"`
-	DefaultProject     string `json:"defaultProject"`
-	FlatRateProject    string `json:"flatRateProject"`
-	TokenUri           string `json:"tokenUri"`
-	QueryPriority      string `json:"queryPriority"`
-	ProcessingLocation string `json:"processingLocation"`
-	MaxBytesBilled     int64  `json:"MaxBytesBilled,omitempty"`
-	Updated            time.Time
-	AuthenticationType string `json:"authenticationType"`
-	PrivateKeyPath     string `json:"privateKeyPath"`
-	ServiceEndpoint    string `json:"serviceEndpoint"`
+	DatasourceId                int64  `json:"datasourceId"`
+	ClientEmail                 string `json:"clientEmail"`
+	DefaultProject              string `json:"defaultProject"`
+	FlatRateProject             string `json:"flatRateProject"`
+	TokenUri                    string `json:"tokenUri"`
+	QueryPriority               string `json:"queryPriority"`
+	ProcessingLocation          string `json:"processingLocation"`
+	MaxBytesBilled              int64  `json:"MaxBytesBilled,omitempty"`
+	Updated                     time.Time
+	AuthenticationType          string `json:"authenticationType"`
+	PrivateKeyPath              string `json:"privateKeyPath"`
+	ServiceEndpoint             string `json:"serviceEndpoint"`
+	UsingImpersonation          bool   `json:"usingImpersonation"`
+	ServiceAccountToImpersonate string `json:"serviceAccountToImpersonate"`
 
 	// Saved in secure JSON
 	PrivateKey string `json:"-"`


### PR DESCRIPTION
Superseded by https://github.com/grafana/google-bigquery-datasource/pull/344

This PR adds support for [service account impersonation](https://cloud.google.com/iam/docs/service-account-impersonation). It depends on the changes introduced in https://github.com/grafana/grafana-google-sdk-go/pull/12

Note: I have not been able to get a binary built and written to disk so that I can test that these changes produce the desired result. If you have any advice as to how I can do so, that would be much appreciated!

TODO: Make changes to configuration web page to allow configuration via Grafana UI.