### PR TITLE
Remove deprecated components, functions and types / interfaces from the frontend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,19 +17,13 @@ Make sure you have the following dependencies installed first:
 1. Install dependencies
 
    ```bash
-   yarn install --pure-lockfile
+   yarn install
    ```
 
-2. Build plugin in development mode or run in watch mode
+2. Build plugin in development mode
 
    ```bash
    yarn dev
-   ```
-
-   or
-
-   ```bash
-   yarn watch
    ```
 
 3. Build plugin in production mode
@@ -44,6 +38,11 @@ Make sure you have the following dependencies installed first:
 
    ```bash
    mage -v
+   ```
+2. Start Grafana in Docker
+
+   ```bash
+   yarn server
    ```
 
 ## Submitting PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,14 @@ Make sure you have the following dependencies installed first:
    yarn server
    ```
 
+## Testing
+
+1. Testing the frontend
+
+   ```bash
+   yarn test
+   ```
+
 ## Submitting PR
 
 If you are creating a PR, ensure to run `yarn changeset` from your branch. Provide the details accordingly. It will create `*.md` file inside `./.changeset` folder. Later during the release, based on these changesets, package version will be bumped and changelog will be generated.

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -7,7 +7,7 @@ import {
 import { AuthConfig, DataSourceOptions, DataSourceSecureJsonData } from '@grafana/google-sdk';
 import { ConfigSection, DataSourceDescription } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
-import { Field, Input, SecureSocksProxySettings, Select } from '@grafana/ui';
+import { Field, Input, SecureSocksProxySettings, Combobox } from '@grafana/ui';
 import React from 'react';
 import { PROCESSING_LOCATIONS } from '../constants';
 import { BigQueryAuth, bigQueryAuthTypes, BigQueryOptions, BigQuerySecureJsonData } from '../types';
@@ -95,13 +95,12 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
             </span>
           }
         >
-          <Select
-            className="width-30"
+          <Combobox
+            width={60}
             placeholder="Automatic location selection"
             value={jsonData.processingLocation || ''}
             options={PROCESSING_LOCATIONS}
             onChange={onUpdateDatasourceJsonDataOptionSelect(props, 'processingLocation')}
-            menuShouldPortal={true}
           />
         </Field>
         <Field

--- a/src/components/DatasetSelector.tsx
+++ b/src/components/DatasetSelector.tsx
@@ -1,5 +1,5 @@
 import { SelectableValue } from '@grafana/data';
-import { Select } from '@grafana/ui';
+import { Combobox } from '@grafana/ui';
 import React, { useEffect } from 'react';
 import { useAsync } from 'react-use';
 import { ResourceSelectorProps } from 'types';
@@ -22,7 +22,6 @@ export const DatasetSelector: React.FC<DatasetSelectorProps> = ({
   project,
   onChange,
   disabled,
-  className,
   applyDefault,
   inputId,
 }) => {
@@ -51,16 +50,14 @@ export const DatasetSelector: React.FC<DatasetSelectorProps> = ({
   }, [state.value, value, location, applyDefault, onChange]);
 
   return (
-    <Select
-      className={className}
+    <Combobox
       aria-label="Dataset selector"
-      inputId={inputId}
+      id={inputId}
       value={value}
-      options={state.value}
+      options={state.value ?? []}
       onChange={onChange}
       disabled={disabled}
-      isLoading={state.loading}
-      menuShouldPortal={true}
+      loading={state.loading}
     />
   );
 };

--- a/src/components/DatasetSelector.tsx
+++ b/src/components/DatasetSelector.tsx
@@ -1,5 +1,5 @@
 import { SelectableValue } from '@grafana/data';
-import { Combobox } from '@grafana/ui';
+import { Select } from '@grafana/ui';
 import React, { useEffect } from 'react';
 import { useAsync } from 'react-use';
 import { ResourceSelectorProps } from 'types';
@@ -22,6 +22,7 @@ export const DatasetSelector: React.FC<DatasetSelectorProps> = ({
   project,
   onChange,
   disabled,
+  className,
   applyDefault,
   inputId,
 }) => {
@@ -50,14 +51,21 @@ export const DatasetSelector: React.FC<DatasetSelectorProps> = ({
   }, [state.value, value, location, applyDefault, onChange]);
 
   return (
-    <Combobox
+    // There is a known issue with ComboBox where user needs to start typing into the input to see the options.
+    // See: https://github.com/grafana/grafana/issues/108400
+    // Likely not ideal to migrate to ComboBox at this point.
+    // TODO: Migrate to ComboBox when the issue is resolved.
+    // eslint-disable-next-line deprecation/deprecation
+    <Select
+      className={className}
       aria-label="Dataset selector"
-      id={inputId}
+      inputId={inputId}
       value={value}
-      options={state.value ?? []}
+      options={state.value}
       onChange={onChange}
       disabled={disabled}
-      loading={state.loading}
+      isLoading={state.loading}
+      menuShouldPortal={true}
     />
   );
 };

--- a/src/components/ProjectSelector.tsx
+++ b/src/components/ProjectSelector.tsx
@@ -1,6 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 import { EditorField } from '@grafana/plugin-ui';
-import { Select, useTheme2 } from '@grafana/ui';
+import { Combobox, useTheme2 } from '@grafana/ui';
 import React, { useEffect } from 'react';
 import { css } from '@emotion/css';
 import { useAsync } from 'react-use';
@@ -68,14 +68,13 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   return (
     <div className={css({ width: theme.spacing(25) })}>
       <EditorField label="Project" width={25} error={getErrorMessage()} invalid={!!state.error}>
-        <Select
+        <Combobox
           aria-label="Project selector"
-          inputId={inputId}
+          id={inputId}
           value={state.loading ? null : value}
           options={state.loading ? [] : state.value || [{ label: value, value }]}
           onChange={onChange}
-          isLoading={state.loading}
-          menuShouldPortal={true}
+          loading={state.loading}
         />
       </EditorField>
     </div>

--- a/src/components/TableSelector.tsx
+++ b/src/components/TableSelector.tsx
@@ -1,5 +1,5 @@
 import { SelectableValue } from '@grafana/data';
-import { Combobox } from '@grafana/ui';
+import { Select } from '@grafana/ui';
 import React from 'react';
 import { useAsync } from 'react-use';
 import { toOption } from 'utils/data';
@@ -16,6 +16,7 @@ export const TableSelector: React.FC<TableSelectorProps> = ({
   apiClient,
   query,
   value,
+  className,
   onChange,
   inputId,
 }) => {
@@ -28,14 +29,21 @@ export const TableSelector: React.FC<TableSelectorProps> = ({
   }, [query]);
 
   return (
-    <Combobox
+    // There is a known issue with ComboBox where user needs to start typing into the input to see the options.
+    // See: https://github.com/grafana/grafana/issues/108400
+    // Likely not ideal to migrate to ComboBox at this point.
+    // TODO: Migrate to ComboBox when the issue is resolved.z
+    // eslint-disable-next-line deprecation/deprecation
+    <Select
+      className={className}
       disabled={state.loading}
-      id={inputId}
+      inputId={inputId}
       aria-label="Table selector"
       value={value}
-      options={state.value ?? []}
+      options={state.value}
       onChange={onChange}
-      loading={state.loading}
+      isLoading={state.loading}
+      menuShouldPortal={true}
       placeholder={state.loading ? 'Loading tables' : 'Select table'}
     />
   );

--- a/src/components/TableSelector.tsx
+++ b/src/components/TableSelector.tsx
@@ -1,5 +1,5 @@
 import { SelectableValue } from '@grafana/data';
-import { Select } from '@grafana/ui';
+import { Combobox } from '@grafana/ui';
 import React from 'react';
 import { useAsync } from 'react-use';
 import { toOption } from 'utils/data';
@@ -16,7 +16,6 @@ export const TableSelector: React.FC<TableSelectorProps> = ({
   apiClient,
   query,
   value,
-  className,
   onChange,
   inputId,
 }) => {
@@ -29,16 +28,14 @@ export const TableSelector: React.FC<TableSelectorProps> = ({
   }, [query]);
 
   return (
-    <Select
-      className={className}
+    <Combobox
       disabled={state.loading}
-      inputId={inputId}
+      id={inputId}
       aria-label="Table selector"
       value={value}
-      options={state.value}
+      options={state.value ?? []}
       onChange={onChange}
-      isLoading={state.loading}
-      menuShouldPortal={true}
+      loading={state.loading}
       placeholder={state.loading ? 'Loading tables' : 'Select table'}
     />
   );

--- a/src/components/query-editor-raw/QueryToolbox.tsx
+++ b/src/components/query-editor-raw/QueryToolbox.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { HorizontalGroup, Icon, IconButton, Tooltip, useTheme2 } from '@grafana/ui';
+import { Icon, IconButton, Stack, Tooltip, useTheme2 } from '@grafana/ui';
 import { QueryValidator, QueryValidatorProps } from './QueryValidator';
 import { css } from '@emotion/css';
 
@@ -66,7 +66,7 @@ export function QueryToolbox({ showTools, onFormatCode, onExpand, isExpanded, ..
       </div>
       {showTools && (
         <div>
-          <HorizontalGroup spacing="sm">
+          <Stack gap={1}>
             {onFormatCode && (
               <IconButton onClick={onFormatCode} name="brackets-curly" size="xs" tooltip="Format query" />
             )}
@@ -81,7 +81,7 @@ export function QueryToolbox({ showTools, onFormatCode, onExpand, isExpanded, ..
             <Tooltip content="Hit CTRL/CMD+Return to run query">
               <Icon className={styles.hint} name="keyboard" />
             </Tooltip>
-          </HorizontalGroup>
+          </Stack>
         </div>
       )}
     </div>

--- a/src/components/visual-query-builder/AwesomeQueryBuilder.tsx
+++ b/src/components/visual-query-builder/AwesomeQueryBuilder.tsx
@@ -1,5 +1,5 @@
 import { dateTime } from '@grafana/data';
-import { Button, DateTimePicker, Input, Select } from '@grafana/ui';
+import { Button, Combobox, DateTimePicker, Input, Select } from '@grafana/ui';
 import { BasicConfig, Config, JsonItem, Settings, Utils, Widgets } from '@react-awesome-query-builder/ui';
 import React from 'react';
 import { toOption } from 'utils/data';
@@ -79,11 +79,10 @@ export const settings: Settings = {
   deleteLabel: buttonLabels.remove,
   renderConjs: function Conjunctions(conjProps) {
     return (
-      <Select
+      <Combobox
         id={conjProps?.id}
         aria-label="Conjunction"
-        menuShouldPortal
-        options={conjProps?.conjunctionOptions ? Object.keys(conjProps?.conjunctionOptions).map(toOption) : undefined}
+        options={conjProps?.conjunctionOptions ? Object.keys(conjProps?.conjunctionOptions).map(toOption) : Object.keys(BasicConfig.conjunctions).map(toOption)}
         value={conjProps?.selectedConjunction}
         onChange={(val) => conjProps?.setConjunction(val.value!)}
       />
@@ -122,10 +121,9 @@ export const settings: Settings = {
   },
   renderOperator: function Operator(operatorProps) {
     return (
-      <Select
+      <Combobox
         options={operatorProps?.items.map((op) => ({ label: op.label, value: op.key }))}
         aria-label="Operator"
-        menuShouldPortal
         value={operatorProps?.selectedKey}
         onChange={(val) => {
           operatorProps?.setField(val.value || '');

--- a/src/components/visual-query-builder/AwesomeQueryBuilder.tsx
+++ b/src/components/visual-query-builder/AwesomeQueryBuilder.tsx
@@ -90,6 +90,8 @@ export const settings: Settings = {
   },
   renderField: function Field(fieldProps) {
     return (
+      // TODO: migrate this to ComboBox when we find a way to use ComboBox with icons. Disabling lint warning for now 
+      // eslint-disable-next-line deprecation/deprecation
       <Select
         id={fieldProps?.id}
         width={25}

--- a/src/components/visual-query-builder/SQLGroupByRow.tsx
+++ b/src/components/visual-query-builder/SQLGroupByRow.tsx
@@ -49,6 +49,8 @@ function makeRenderColumn({ options }: { options?: Array<SelectableValue<string>
   ) {
     return (
       <InputGroup>
+        {/* TODO: migrate this to ComboBox when we find a way to use ComboBox with icons. Disabling lint warning for now */}
+        {/* eslint-disable-next-line deprecation/deprecation */}
         <Select
           value={isQueryEditorGroupByExpression(item) && item.property?.name ? toOption(item.property.name) : null}
           aria-label="Group by"

--- a/src/components/visual-query-builder/SQLOrderByRow.tsx
+++ b/src/components/visual-query-builder/SQLOrderByRow.tsx
@@ -59,6 +59,8 @@ export function SQLOrderByRow({ sql, onSqlChange, columns, showOffset }: SQLOrde
     <>
       <EditorField label="Order by" width={25}>
         <InputGroup>
+          {/* TODO: migrate this to ComboBox when we find a way to use ComboBox with icons. Disabling lint warning for now */}
+          {/* eslint-disable-next-line deprecation/deprecation */}
           <Select
             aria-label="Order by"
             options={columns}

--- a/src/components/visual-query-builder/SQLSelectRow.tsx
+++ b/src/components/visual-query-builder/SQLSelectRow.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/css';
-import { SelectableValue } from '@grafana/data';
 import { EditorField } from '@grafana/plugin-ui';
-import { useStyles2, Select, Button, Stack } from '@grafana/ui';
+import { useStyles2, Button, Stack, Combobox, ComboboxOption, Select } from '@grafana/ui';
 import { QueryEditorExpressionType, QueryEditorFunctionExpression } from 'expressions';
 import { uniqueId } from 'lodash';
 import React, { useCallback } from 'react';
@@ -9,6 +8,7 @@ import { toOption } from 'utils/data';
 import { createFunctionField } from 'utils/sql.utils';
 import { SQLExpression } from '../../types';
 import { BQ_AGGREGATE_FNS } from '../query-editor-raw/bigQueryFunctions';
+import { SelectableValue } from '@grafana/data';
 
 interface SQLSelectRowProps {
   sql: SQLExpression;
@@ -44,7 +44,7 @@ export function SQLSelectRow({ sql, columns, onSqlChange }: SQLSelectRowProps) {
   );
 
   const onAggregationChange = useCallback(
-    (item: QueryEditorFunctionExpression, index: number) => (aggregation: SelectableValue<string>) => {
+    (item: QueryEditorFunctionExpression, index: number) => (aggregation: ComboboxOption<string> | null) => {
       const newItem = {
         ...item,
         name: aggregation?.value,
@@ -94,12 +94,11 @@ export function SQLSelectRow({ sql, columns, onSqlChange }: SQLSelectRowProps) {
             </EditorField>
 
             <EditorField label="Aggregation" optional width={25}>
-              <Select
+              <Combobox
                 value={item.name ? toOption(item.name) : null}
-                inputId={`select-aggregation-${index}-${uniqueId()}`}
+                id={`select-aggregation-${index}-${uniqueId()}`}
                 isClearable
-                menuShouldPortal
-                allowCustomValue
+                createCustomValue
                 options={aggregateFnOptions}
                 onChange={onAggregationChange(item, index)}
               />
@@ -134,7 +133,7 @@ const getStyles = () => {
 
 const aggregateFnOptions = BQ_AGGREGATE_FNS.map((v) => toOption(v.name));
 
-function getColumnValue({ parameters }: QueryEditorFunctionExpression): SelectableValue<string> | null {
+function getColumnValue({ parameters }: QueryEditorFunctionExpression): ComboboxOption<string> | null {
   const column = parameters?.find((p) => p.type === QueryEditorExpressionType.FunctionParameter);
   if (column?.name) {
     return toOption(column.name);

--- a/src/components/visual-query-builder/SQLSelectRow.tsx
+++ b/src/components/visual-query-builder/SQLSelectRow.tsx
@@ -83,6 +83,8 @@ export function SQLSelectRow({ sql, columns, onSqlChange }: SQLSelectRowProps) {
         <div key={index}>
           <Stack gap={2} alignItems="end">
             <EditorField label="Column" width={25}>
+              {/* TODO: migrate this to ComboBox when we find a way to use ComboBox with icons. Disabling lint warning for now */}
+              {/* eslint-disable-next-line deprecation/deprecation */}
               <Select
                 value={getColumnValue(item)}
                 options={columnsWithAsterisk}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,12 +1,13 @@
 import { SelectableValue } from '@grafana/data';
 import { QueryFormat, QueryPriority } from './types';
+import { ComboboxOption } from '@grafana/ui';
 
 export const QUERY_FORMAT_OPTIONS = [
   { label: 'Time series', value: QueryFormat.Timeseries },
   { label: 'Table', value: QueryFormat.Table },
 ];
 
-export const PROCESSING_LOCATIONS: Array<SelectableValue<string>> = [
+export const PROCESSING_LOCATIONS: Array<ComboboxOption<string>> = [
   // Allow BigQuery to select the processing location.
   { label: 'Automatic location selection', value: '' },
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,5 +1,4 @@
 import {
-  DataQuery,
   DataQueryRequest,
   DataSourceInstanceSettings,
   ScopedVars,
@@ -12,6 +11,7 @@ import { uniqueId } from 'lodash';
 import { VariableEditor } from './components/VariableEditor';
 import { BigQueryOptions, BigQueryQueryNG, BigQueryAuth, QueryFormat, QueryModel } from './types';
 import { interpolateVariable } from './utils/interpolateVariable';
+import { DataQuery } from '@grafana/schema';
 
 export class BigQueryDatasource extends DataSourceWithBackend<BigQueryQueryNG, BigQueryOptions> {
   jsonData: BigQueryOptions;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { DataQuery, TimeRange } from '@grafana/data';
+import { TimeRange } from '@grafana/data';
 import {
   DataSourceOptions,
   DataSourceSecureJsonData,
@@ -6,6 +6,7 @@ import {
   GoogleAuthType,
 } from '@grafana/google-sdk';
 import { EditorMode } from '@grafana/plugin-ui';
+import { DataQuery } from '@grafana/schema';
 import { JsonTree } from '@react-awesome-query-builder/ui';
 import { BigQueryAPI } from 'api';
 import {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { EditorMode } from '@grafana/plugin-ui';
 import { QueryFormat } from 'types';
-import { applyQueryDefaults, extractFromClause, findTimeField, formatBigqueryError, getShiftPeriod } from 'utils';
+import { applyQueryDefaults, extractFromClause, findTimeField, formatBigqueryError, getShiftPeriod, handleError } from 'utils';
 
 describe('Utils', () => {
   test('formatBigqueryError', () => {
@@ -62,5 +62,102 @@ describe('Utils', () => {
     const res = applyQueryDefaults(query, { jsonData: { processingLocation: 'US' } } as any);
 
     expect(res.location).toBe('');
+  });
+
+  test('handleError should return [] when cancelled is true', () => {
+    const res = handleError({ cancelled: true });
+    expect(res).toEqual([]);
+  });
+
+  test('handleError should throw formatted error when error.data.error is present', () => {
+    const inner = { message: 'status text', code: '505', errors: [{ reason: 'just like that' }] };
+    const err = { data: { error: inner } };
+    try {
+      handleError(err);
+      // should not reach here
+      throw new Error('handleError did not throw');
+    } catch (e: any) {
+      expect(e.data.message).toBe('just like that: status text');
+      expect(e.status).toBe('505');
+      expect(e.statusText).toContain('BigQuery: status text');
+    }
+  });
+
+  test('handleError should throw formatted error when passed plain error object', () => {
+    const err = { message: 'status text', code: '505', errors: [{ reason: 'just like that' }] };
+    try {
+      handleError(err);
+      throw new Error('handleError did not throw');
+    } catch (e: any) {
+      expect(e.data.message).toBe('just like that: status text');
+    }
+  });
+
+  test('formatDateToString formats date correctly with separators and time', () => {
+    const d = new Date(Date.UTC(2020, 0, 2, 3, 4, 5)); // 2020-01-02T03:04:05Z
+    const { formatDateToString } = require('utils');
+    const r = formatDateToString(d, '-', true);
+    expect(r).toMatch(/^2020-01-02 03:04:05$/);
+  });
+
+  test('quoteLiteral and escapeLiteral work as expected', () => {
+    const { quoteLiteral, escapeLiteral } = require('utils');
+    expect(quoteLiteral("O'Reilly")).toBe("'O''Reilly'");
+    expect(escapeLiteral("O'Reilly")).toBe("O''Reilly");
+  });
+
+  test('quoteFiledName quotes dotted identifiers', () => {
+    const { quoteFiledName } = require('utils');
+    expect(quoteFiledName('project.dataset.table')).toBe('`project`.`dataset`.`table`');
+    expect(quoteFiledName('col')).toBe('`col`');
+  });
+
+  test('getInterval extracts interval and value', () => {
+    const { getInterval } = require('utils');
+    const q = '$__timeGroup(col, 1m, 10)';
+    const res = getInterval(q, false);
+    expect(res[0]).toBe('1m');
+    expect(res[1]).toBe('10');
+  });
+
+  test('getInterval extracts interval and value with alias', () => {
+    const { getInterval } = require('utils');
+    const q = '$__timeGroupAlias(col, 1m, 10)';
+    const res = getInterval(q, true);
+    expect(res[0]).toBe('1m');
+    expect(res[1]).toBe('10');
+  });
+  
+
+  test('getTimeShift and replaceTimeShift behave as expected', () => {
+    const { getTimeShift, replaceTimeShift } = require('utils');
+    const sql = 'select $__timeShifting(55 min) as shifted';
+    expect(getTimeShift(sql)).toBe('55 min');
+    const replaced = replaceTimeShift(sql);
+    expect(replaced).not.toContain('$__timeShifting(');
+  });
+
+  test('getUnixSecondsFromString handles different periods', () => {
+    const { getUnixSecondsFromString } = require('utils');
+    expect(getUnixSecondsFromString('5s')).toBe(5);
+    expect(getUnixSecondsFromString('2 min')).toBe(120);
+    expect(getUnixSecondsFromString('1h')).toBe(3600);
+    expect(getUnixSecondsFromString(undefined)).toBe(0);
+  });
+
+  test('convertToUtc applies timezone offset', () => {
+    const { convertToUtc } = require('utils');
+    const d = new Date();
+    const expected = new Date(d.getTime() + d.getTimezoneOffset() * 60000);
+    const res = convertToUtc(d);
+    expect(res.getTime()).toBe(expected.getTime());
+  });
+
+  test('isQueryValid and datasource id setters/getters', () => {
+    const { isQueryValid, setDatasourceId, getDatasourceId } = require('utils');
+    expect(isQueryValid({ rawSql: 'select 1' })).toBe(true);
+    expect(isQueryValid({})).toBe(false);
+    setDatasourceId(999);
+    expect(getDatasourceId()).toBe(999);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,7 +50,7 @@ export function formatBigqueryError(error: any) {
 
 export function getShiftPeriod(strInterval: string): [DurationUnit, string] {
   const shift = strInterval.match(/\d+/)![0];
-  strInterval = strInterval.substr(shift.length, strInterval.length);
+  strInterval = strInterval.substring(shift.length, strInterval.length);
 
   if (strInterval.trim() === 'min') {
     strInterval = 'm';
@@ -156,11 +156,11 @@ export function updatePartition(q: string, options: DataQueryRequest<BigQueryQue
   if (q.indexOf('AND _PARTITIONTIME <') < 1) {
     return q;
   }
-  const from = q.substr(q.indexOf('AND _PARTITIONTIME >= ') + 22, 21);
+  const from = q.substring(q.indexOf('AND _PARTITIONTIME >= ') + 22, 21);
 
   const newFrom = "'" + formatDateToString(options.range.from.toDate(), '-', true) + "'";
   q = q.replace(from, newFrom);
-  const to = q.substr(q.indexOf('AND _PARTITIONTIME < ') + 21, 21);
+  const to = q.substring(q.indexOf('AND _PARTITIONTIME < ') + 21, 21);
   const newTo = "'" + formatDateToString(options.range.to.toDate(), '-', true) + "'";
 
   q = q.replace(to, newTo) + '\n ';
@@ -172,11 +172,11 @@ export function updateTableSuffix(q: string, options: DataQueryRequest<BigQueryQ
   if (ind < 1) {
     return q;
   }
-  const from = q.substr(ind + 28, 8);
+  const from = q.substring(ind + 28, 8);
 
   const newFrom = formatDateToString(options.range.from.toDate());
   q = q.replace(from, newFrom);
-  const to = q.substr(ind + 43, 8);
+  const to = q.substring(ind + 43, 8);
   const newTo = formatDateToString(options.range.to.toDate());
   q = q.replace(to, newTo) + '\n ';
   return q;
@@ -215,7 +215,7 @@ export function formatDateToString(inputDate: Date, separator = '', addTime = fa
   // create the format you want
   let dateStr = YYYY + separator + MM + separator + DD;
   if (addTime === true) {
-    dateStr += ' ' + date.toTimeString().substr(0, 8);
+    dateStr += ' ' + date.toTimeString().substring(0, 8);
   }
   return dateStr;
 }
@@ -264,7 +264,7 @@ export function getTimeShift(q: string) {
   let result = null;
 
   if (res) {
-    result = res[0].substr(1 + res[0].lastIndexOf('('));
+    result = res[0].substring(1 + res[0].lastIndexOf('('));
   }
   return result;
 }

--- a/src/utils/data.test.ts
+++ b/src/utils/data.test.ts
@@ -1,0 +1,19 @@
+import { toOption } from './data';
+
+describe('toOption', () => {
+  test('returns ComboboxOption with label and value', () => {
+    const res = toOption('abc');
+    expect(res).toEqual({ label: 'abc', value: 'abc' });
+  });
+
+  test('handles empty string', () => {
+    const res = toOption('');
+    expect(res).toEqual({ label: '', value: '' });
+  });
+
+  test('preserves special characters and whitespace', () => {
+    const val = "a b@#%/\\'";
+    const res = toOption(val);
+    expect(res).toEqual({ label: val, value: val });
+  });
+});

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -1,5 +1,4 @@
-import { SelectableValue, toOption as toOptionFromData } from '@grafana/data';
+import { ComboboxOption } from '@grafana/ui';
 
-const backWardToOption = (value: string) => ({ label: value, value }) as SelectableValue<string>;
 
-export const toOption = toOptionFromData ?? backWardToOption;
+export const toOption = (value: string) => ({ label: value, value }) as ComboboxOption<string>;

--- a/src/utils/getColumnInfoFromSchema.test.ts
+++ b/src/utils/getColumnInfoFromSchema.test.ts
@@ -1,0 +1,63 @@
+import { getColumnInfoFromSchema } from './getColumnInfoFromSchema';
+
+describe('getColumnInfoFromSchema', () => {
+  test('returns type and description for top-level column', () => {
+    const schema = [
+      { name: 'col', type: 'STRING', description: 'top level', repeated: false } as any,
+    ];
+
+    const res = getColumnInfoFromSchema('col', schema);
+    expect(res).toEqual({ type: 'STRING', description: 'top level' });
+  });
+
+  test('returns nested field info', () => {
+    const schema = [
+      {
+        name: 'a',
+        type: 'RECORD',
+        schema: [{ name: 'b', type: 'INT64', description: 'nested', repeated: false }],
+      } as any,
+    ];
+
+    const res = getColumnInfoFromSchema('a.b', schema);
+    expect(res).toEqual({ type: 'INT64', description: 'nested' });
+  });
+
+  test('marks repeated fields with prefix', () => {
+    const schema = [
+      {
+        name: 'a',
+        type: 'RECORD',
+        schema: [{ name: 'b', type: 'INT64', description: 'nested', repeated: true }],
+      } as any,
+    ];
+
+    const res = getColumnInfoFromSchema('a.b', schema);
+    expect(res).toEqual({ type: 'Repeated INT64', description: 'nested' });
+  });
+
+  test('handles deep nested paths', () => {
+    const schema = [
+      {
+        name: 'a',
+        type: 'RECORD',
+        schema: [
+          {
+            name: 'b',
+            type: 'RECORD',
+            schema: [{ name: 'c', type: 'BOOL', description: 'deep', repeated: false }],
+          },
+        ],
+      } as any,
+    ];
+
+    const res = getColumnInfoFromSchema('a.b.c', schema);
+    expect(res).toEqual({ type: 'BOOL', description: 'deep' });
+  });
+
+  test('returns null when not found', () => {
+    const schema = [{ name: 'x', type: 'STRING', repeated: false } as any];
+    const res = getColumnInfoFromSchema('y', schema);
+    expect(res).toBeNull();
+  });
+});

--- a/src/utils/getColumnInfoFromSchema.ts
+++ b/src/utils/getColumnInfoFromSchema.ts
@@ -10,7 +10,7 @@ export const getColumnInfoFromSchema = (
     const f = schema.find((f) => f.name === c[i]);
 
     if (f && c[i + 1] !== undefined) {
-      return getColumnInfoFromSchema(column.substr(c[i].length + 1), f?.schema);
+      return getColumnInfoFromSchema(column.substring(c[i].length + 1), f?.schema);
     } else if (f) {
       return { type: f.repeated ? `Repeated ${f.type}` : f.type, description: f.description };
     }

--- a/src/utils/interpolateVariable.test.ts
+++ b/src/utils/interpolateVariable.test.ts
@@ -1,39 +1,39 @@
-import { VariableModel } from '@grafana/data';
+import { TypedVariableModel } from '@grafana/data';
 import { interpolateVariable } from './interpolateVariable';
 
 describe('Interpolating variables', () => {
   describe('and value is a string', () => {
     it('should return an unquoted value', () => {
-      expect(interpolateVariable('abc', {} as unknown as VariableModel)).toEqual('abc');
+      expect(interpolateVariable('abc', {} as unknown as TypedVariableModel)).toEqual('abc');
     });
   });
   describe('and value is a number', () => {
     it('should return an unquoted value', () => {
-      expect(interpolateVariable(1000, {} as unknown as VariableModel)).toEqual(1000);
+      expect(interpolateVariable(1000, {} as unknown as TypedVariableModel)).toEqual(1000);
     });
   });
   describe('and value is an array of strings', () => {
     it('should return comma separated quoted values', () => {
-      expect(interpolateVariable(['a', 'b', 'c'], {} as unknown as VariableModel)).toEqual("'a','b','c'");
+      expect(interpolateVariable(['a', 'b', 'c'], {} as unknown as TypedVariableModel)).toEqual("'a','b','c'");
     });
   });
 
   describe('and variable allows multi-value and is a string', () => {
     it('should return a quoted value', () => {
-      expect(interpolateVariable('abc', { multi: true } as unknown as VariableModel)).toEqual("'abc'");
+      expect(interpolateVariable('abc', { multi: true } as unknown as TypedVariableModel)).toEqual("'abc'");
     });
   });
 
   describe('and variable contains single quote', () => {
     it('should return a quoted value', () => {
-      expect(interpolateVariable("a'bc", { multi: true } as unknown as VariableModel)).toEqual("'a''bc'");
-      expect(interpolateVariable("a'b'c", { multi: true } as unknown as VariableModel)).toEqual("'a''b''c'");
+      expect(interpolateVariable("a'bc", { multi: true } as unknown as TypedVariableModel)).toEqual("'a''bc'");
+      expect(interpolateVariable("a'b'c", { multi: true } as unknown as TypedVariableModel)).toEqual("'a''b''c'");
     });
   });
 
   describe('and variable allows all and is a string', () => {
     it('should return a quoted value', () => {
-      expect(interpolateVariable('abc', { includeAll: true } as unknown as VariableModel)).toEqual("'abc'");
+      expect(interpolateVariable('abc', { includeAll: true } as unknown as TypedVariableModel)).toEqual("'abc'");
     });
   });
 });

--- a/src/utils/interpolateVariable.ts
+++ b/src/utils/interpolateVariable.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
-import { VariableModel } from '@grafana/data';
 import { quoteLiteral } from '../utils';
+import { TypedVariableModel } from '@grafana/data';
 
-export function interpolateVariable(value: any, variable: VariableModel) {
+export function interpolateVariable(value: any, variable: TypedVariableModel) {
   if (typeof value === 'string') {
     // @ts-ignore
     if (variable.multi || variable.includeAll) {

--- a/src/utils/useColumns.ts
+++ b/src/utils/useColumns.ts
@@ -1,10 +1,10 @@
-import { SelectableValue } from '@grafana/data';
 // import { queries } from '@testing-library/dom';
 import { getApiClient } from 'api';
 import { useAsync } from 'react-use';
 import { QueryWithDefaults } from '../types';
 import { getDatasourceId } from '../utils';
 import { getColumnInfoFromSchema } from './getColumnInfoFromSchema';
+import { SelectableValue } from '@grafana/data';
 
 type Options = {
   query: QueryWithDefaults;


### PR DESCRIPTION
This PR addresses some of the frontend warnings we were getting for deprecated functions / components / types:

<img width="1292" height="249" alt="Screenshot 2025-08-20 at 11 53 20 AM" src="https://github.com/user-attachments/assets/aa5a0367-9b69-46cc-ae0a-b3b5beb0048a" />

Most of them were able to be migrated to the supported version, however, for some of them, they were kept as is and used lint disable deprecation warning instead. The reasons were:

1. I could not find a way to use icons with the options in a `ComboBox` the way we do today for column drop-downs using `Select`
2. There is a known issue with `ComboBox` (see: https://github.com/grafana/grafana/issues/108400) where on initial load, no options are shown until something is typed into the box. Figured it might be better to wait for this to be fixed before we migrate

In addition to the above, this PR also:
1. Does some minor doc updates
2. Adds tests :)

There were no visual changes when migrating to `ComboBox`

How to test:
1. Playing around with the Query Editor in Builder and Code mode
2. Playing around with the datasource Config Editor

All components should work and render as expected