### PR TITLE
Fix: Add support for JSON, RANGE, INTERVAL types

### DIFF
--- a/.changeset/red-wings-turn.md
+++ b/.changeset/red-wings-turn.md
@@ -1,0 +1,5 @@
+---
+'grafana-bigquery-datasource': patch
+---
+
+Fix: Add support for JSON, RANGE, INTERVAL types

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -41,6 +41,7 @@
     "millis",
     "mininterval",
     "Montréal",
+    "Nanos",
     "northamerica",
     "PARTITIONDATE",
     "PARTITIONTIME",

--- a/pkg/bigquery/driver/rows.go
+++ b/pkg/bigquery/driver/rows.go
@@ -76,6 +76,8 @@ func (r *rows) bigqueryTypeOf(columnType *string) (reflect.Type, error) {
 		return reflect.TypeOf(false), nil
 	case "TIMESTAMP":
 		return reflect.TypeOf(time.Time{}), nil
+	case "JSON", "INTERVAL", "RANGE":
+		return reflect.TypeOf(""), nil
 	case "DATE", "TIME", "DATETIME":
 		return reflect.TypeOf(""), nil
 	case "RECORD", "GEOGRAPHY":

--- a/pkg/bigquery/driver/utils_test.go
+++ b/pkg/bigquery/driver/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/civil"
@@ -364,6 +365,70 @@ func Test_ConvertColumnValue(t *testing.T) {
 			},
 			expectedType:  "[]interface {}",
 			expectedValue: "[null,{\"col1\":2,\"col2\":2.99999,\"col3\":\"text value 2\",\"col4\":\"02:02:02\",\"col5\":\"2019-02-02 01:01:01\"}]",
+		},
+		{
+			name:          "TIMESTAMP",
+			value:         bigquery.Value(time.Date(2023, 12, 25, 10, 30, 45, 123456789, time.UTC)),
+			columnType:    "TIMESTAMP",
+			schema:        &bigquery.FieldSchema{Type: "TIMESTAMP"},
+			expectedType:  "time.Time",
+			expectedValue: "2023-12-25 10:30:45.123456789 +0000 UTC",
+		},
+		{
+			name:          "TIMESTAMP repeated",
+			value:         bigquery.Value([]bigquery.Value{time.Date(2023, 12, 25, 10, 30, 45, 0, time.UTC), time.Date(2023, 12, 26, 11, 31, 46, 0, time.UTC)}),
+			columnType:    "TIMESTAMP",
+			schema:        &bigquery.FieldSchema{Type: "TIMESTAMP", Repeated: true},
+			expectedType:  "string",
+			expectedValue: "2023-12-25 10:30:45 +0000 UTC,2023-12-26 11:31:46 +0000 UTC",
+		},
+		{
+			name:          "JSON",
+			value:         bigquery.Value(`{"name": "John", "age": 30}`),
+			columnType:    "JSON",
+			schema:        &bigquery.FieldSchema{Type: "JSON"},
+			expectedType:  "string",
+			expectedValue: `{"name": "John", "age": 30}`,
+		},
+		{
+			name:          "JSON repeated",
+			value:         bigquery.Value([]bigquery.Value{`{"name": "John", "age": 30}`, `{"name": "Jane", "age": 25}`}),
+			columnType:    "JSON",
+			schema:        &bigquery.FieldSchema{Type: "JSON", Repeated: true},
+			expectedType:  "string",
+			expectedValue: `{"name": "John", "age": 30},{"name": "Jane", "age": 25}`,
+		},
+		{
+			name:          "INTERVAL",
+			value:         bigquery.Value(&bigquery.IntervalValue{SubSecondNanos: 1000}),
+			columnType:    "INTERVAL",
+			schema:        &bigquery.FieldSchema{Type: "INTERVAL"},
+			expectedType:  "string",
+			expectedValue: "0-0 0 0:0:0.000001",
+		},
+		{
+			name:          "INTERVAL repeated",
+			value:         bigquery.Value([]bigquery.Value{&bigquery.IntervalValue{SubSecondNanos: 1000}, &bigquery.IntervalValue{Years: 1, SubSecondNanos: 2000}}),
+			columnType:    "INTERVAL",
+			schema:        &bigquery.FieldSchema{Type: "INTERVAL", Repeated: true},
+			expectedType:  "string",
+			expectedValue: "0-0 0 0:0:0.000001,1-0 0 0:0:0.000002",
+		},
+		{
+			name:          "RANGE",
+			value:         bigquery.Value(&bigquery.RangeValue{Start: bigquery.Value(1), End: bigquery.Value(5)}),
+			columnType:    "RANGE",
+			schema:        &bigquery.FieldSchema{Type: "RANGE"},
+			expectedType:  "string",
+			expectedValue: "[1,5)",
+		},
+		{
+			name:          "RANGE repeated",
+			value:         bigquery.Value([]bigquery.Value{&bigquery.RangeValue{Start: bigquery.Value(1), End: bigquery.Value(5)}, &bigquery.RangeValue{Start: bigquery.Value(10), End: bigquery.Value(20)}}),
+			columnType:    "RANGE",
+			schema:        &bigquery.FieldSchema{Type: "RANGE", Repeated: true},
+			expectedType:  "string",
+			expectedValue: "[1,5),[10,20)",
 		},
 	}
 

--- a/src/utils/useColumns.ts
+++ b/src/utils/useColumns.ts
@@ -80,6 +80,9 @@ export function mapColumnTypeToIcon(type: string) {
     case 'DECIMAL':
       return 'calculator-alt';
     case 'STRING':
+    case 'JSON':
+    case 'INTERVAL':
+    case 'RANGE':
     case 'BYTES':
       return 'text';
     case 'GEOGRAPHY':


### PR DESCRIPTION
Fixes https://github.com/grafana/google-bigquery-datasource/issues/145

Fixes https://github.com/grafana/google-bigquery-datasource/issues/157

Run the following sql query for test.

```sql
-- Test query to verify all BigQuery data types are working correctly
-- This query creates a temporary table with all supported data types
-- and then queries it to test the ConvertColumnValue function

WITH test_data AS (
  SELECT 
    -- Integer types
    127 AS tinyint_col,
    32767 AS smallint_col,
    2147483647 AS int_col,
    9223372036854775807 AS int64_col,
    
    -- Float types
    3.14159265359 AS float_col,
    2.71828182846 AS float64_col,
    
    -- Numeric types
    NUMERIC '123.456789' AS numeric_col,
    BIGNUMERIC '99999999999999999999999999999999999999.123456789' AS bignumeric_col,
    
    -- String and bytes
    'Hello, BigQuery!' AS string_col,
    b'Hello, Bytes!' AS bytes_col,
    
    -- Boolean
    TRUE AS boolean_col,
    
    -- Date and time types
    DATE '2023-12-25' AS date_col,
    TIME '10:30:45.123456' AS time_col,
    DATETIME '2023-12-25 10:30:45.123456' AS datetime_col,
    TIMESTAMP '2023-12-25 10:30:45.123456 UTC' AS timestamp_col,
    
    -- JSON type
    JSON '{"name": "John Doe", "age": 30, "city": "New York", "active": true}' AS json_col,
    
    -- Interval type
    INTERVAL '1-2 3 4:5:6.789' YEAR TO SECOND AS interval_col,
    
    -- Range type (for DATE)
    RANGE(DATE '2023-01-01', DATE '2023-12-31') AS range_col,
    
    -- Geography type
    ST_GEOGPOINT(-74.006, 40.7128) AS geography_col,
    
    -- Arrays (repeated fields)
    [1, 2, 3, 4, 5] AS int_array,
    [3.14, 2.71, 1.41] AS float_array,
    ['apple', 'banana', 'cherry'] AS string_array,
    [DATE '2023-01-01', DATE '2023-02-01', DATE '2023-03-01'] AS date_array,
    [TIMESTAMP '2023-01-01 00:00:00', TIMESTAMP '2023-02-01 00:00:00'] AS timestamp_array,
    ['{"id": 1}', '{"id": 2}', '{"id": 3}'] AS json_array,
    [INTERVAL '1-0 0 0:0:0' YEAR TO SECOND, INTERVAL '2-0 0 0:0:0' YEAR TO SECOND] AS interval_array,
    [RANGE(DATE '2023-01-01', DATE '2023-06-30'), RANGE(DATE '2023-07-01', DATE '2023-12-31')] AS range_array,
    
    -- Record (STRUCT)
    STRUCT(
      42 AS nested_int,
      'nested string' AS nested_string,
      TRUE AS nested_bool,
      DATE '2023-06-15' AS nested_date
    ) AS record_col,
    
    -- Array of records
    [
      STRUCT(1 AS id, 'first' AS name),
      STRUCT(2 AS id, 'second' AS name),
      STRUCT(3 AS id, 'third' AS name)
    ] AS record_array

)
SELECT 
  -- Basic types
  tinyint_col,
  smallint_col,
  int_col,
  int64_col,
  float_col,
  float64_col,
  numeric_col,
  bignumeric_col,
  string_col,
  bytes_col,
  boolean_col,
  date_col,
  time_col,
  datetime_col,
  timestamp_col,
  json_col,
  interval_col,
  range_col,
  geography_col,
  
  -- Arrays
  int_array,
  float_array,
  string_array,
  date_array,
  timestamp_array,
  json_array,
  interval_array,
  range_array,
  
  -- Records
  record_col,
  record_array,
  
  -- Additional test cases with NULL values
  NULL AS null_timestamp,
  NULL AS null_json,
  NULL AS null_interval,
  NULL AS null_range,
  
  -- Edge cases
  TIMESTAMP '1970-01-01 00:00:00 UTC' AS epoch_timestamp,
  JSON 'null' AS null_json_value,
  JSON '[]' AS empty_json_array,
  JSON '{}' AS empty_json_object,
  INTERVAL '0-0 0 0:0:0' YEAR TO SECOND AS zero_interval,

FROM test_data;

```