### PR TITLE
Chore: Migrate workflows to use create-github-app-token

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,20 +16,12 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
+      - id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
         with:
-          repo_secrets: |
-            GITHUB_APP_ID=grafana-oss-big-tent:app-id
-            GITHUB_APP_PRIVATE_KEY=grafana-oss-big-tent:private-key
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-      - uses: actions/add-to-project@main
+          github_app: grafana-oss-big-tent
+      - name: Add to project
+        uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/grafana/projects/457
-          github-token: ${{ steps.generate-token.outputs.token }}
+          github-token: ${{ steps.get-github-token.outputs.token }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,12 +27,12 @@ on:
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v4.3.0
     with:
-      go-version: '1.25'
-      golangci-lint-version: '2.4.0'
-      github-draft-release: false
+      golangci-lint-version: '2.7.2'
+      go-version: '1.25.5'
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       run-playwright: true
+      github-draft-release: false

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -12,9 +12,9 @@ on:
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v4.3.0
     with:
-      go-version: '1.25'
-      golangci-lint-version: '2.4.0'
+      go-version: '1.25.5'
+      golangci-lint-version: '2.7.2'
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright: true

--- a/.github/workflows/update-create-plugin.yml
+++ b/.github/workflows/update-create-plugin.yml
@@ -7,10 +7,17 @@ on:
 
 permissions:
   contents: write
+  id-token: write # Needed for create-github-app-token
   pull-requests: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: grafana/plugin-actions/create-plugin-update@main
+      - id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
+        with:
+          github_app: grafana-oss-big-tent
+      - uses: grafana/plugin-actions/create-plugin-update@244c3bc9c6eb94bc1dd6458ade2462499bbf0f5b #create-plugin-update/v2.0.1
+        with:
+          token: ${{ steps.get-github-token.outputs.token }}


### PR DESCRIPTION
Fixes https://github.com/grafana/oss-big-tent-squad/issues/143