### PR TITLE
chore: Fix React types to match version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
-    "@testing-library/user-event": "^14.6.1",
+    "@testing-library/user-event": "14.6.1",
     "@trivago/prettier-plugin-sort-imports": "6.0.2",
     "@types/jest": "30.0.0",
     "@types/lodash": "4.17.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3658,7 +3658,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/user-event@npm:^14.6.1":
+"@testing-library/user-event@npm:14.6.1":
   version: 14.6.1
   resolution: "@testing-library/user-event@npm:14.6.1"
   peerDependencies:
@@ -7698,7 +7698,7 @@ __metadata:
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:16.3.2"
-    "@testing-library/user-event": "npm:^14.6.1"
+    "@testing-library/user-event": "npm:14.6.1"
     "@trivago/prettier-plugin-sort-imports": "npm:6.0.2"
     "@types/jest": "npm:30.0.0"
     "@types/lodash": "npm:4.17.23"


### PR DESCRIPTION
Fixes the following issues.

```
➤ YN0060: │ @types/react is listed by your project with version 19.2.13 (p584b79), which doesn't satisfy what react-calendar (via @grafana/plugin-ui) and other dependencies request (but they have non-overlapping ranges!).
➤ YN0060: │ @types/react-dom is listed by your project with version 19.2.3 (p295dbf), which doesn't satisfy what react-redux (via @react-awesome-query-builder/ui) and other dependencies request (^18.0.0).
➤ YN0002: │ grafana-bigquery-datasource@workspace:. doesn't provide @testing-library/user-event (p8a8666), requested by @grafana/plugin-ui.
```
