### PR TITLE
chore: bump Go to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/google-bigquery-datasource
 
-go 1.26.1
+go 1.26.2
 
 require (
 	cloud.google.com/go v0.123.0


### PR DESCRIPTION
Bumps the Go toolchain version in `go.mod` from 1.26.1 to 1.26.2.

Fixes https://github.com/grafana/google-bigquery-datasource/issues/477