### PR TITLE
Docs: BigQuery quarterly update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "specstory.cloudSync.enabled": "always"
+}

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -53,6 +53,7 @@
     "prismjs",
     "projectname",
     "proxying",
+    "resourcemanager",
     "PTRACE",
     "raintank",
     "RAQB",

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -56,6 +56,7 @@ After you configure the BigQuery data source, you can:
 - Add [Transformations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/transform-data/) to manipulate query results.
 - Set up [Alerting](https://grafana.com/docs/plugins/grafana-bigquery-datasource/latest/alerting/) rules based on your BigQuery data.
 - Use [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) to investigate your BigQuery data without building a dashboard.
+- Build queries with [Grafana Assistant](https://grafana.com/docs/plugins/grafana-bigquery-datasource/latest/query-editor/#query-with-grafana-assistant) when it's available in your Grafana instance.
 
 ## Pre-built dashboards
 

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -30,10 +30,18 @@ Before configuring the data source, ensure you have:
 
 - **Grafana version:** 11.6.0 or later (plugin version 3.x). For older Grafana versions, use plugin version 2.x (requires Grafana 10.4.8+) or 1.x.
 - **Grafana permissions:** `Organization administrator` role to add data sources.
-- **Google Cloud APIs enabled:** The following APIs must be enabled in your GCP project:
+- **Google Cloud APIs enabled:** The following APIs must be enabled on each GCP project you query:
   - [BigQuery API](https://console.cloud.google.com/apis/library/bigquery.googleapis.com)
   - [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
 - **Google Cloud credentials:** Depending on your authentication method, you need either a service account key file or access to the Google Metadata Server.
+- **Required GCP IAM roles:** The service account (or impersonated service account) must have the following roles on each project it accesses:
+  - **BigQuery Data Viewer** (`roles/bigquery.dataViewer`) — read access to BigQuery data
+  - **BigQuery Job User** (`roles/bigquery.jobUser`) — permission to run BigQuery jobs
+  - **`resourcemanager.projects.get`** permission — required for the project dropdown to populate in the query editor. This permission is included in the **Browser** role (`roles/browser`) or can be granted through a custom role.
+
+{{< admonition type="note" >}}
+If the service account has project-level access but not dataset or table-level access, **Save & test** may succeed while individual queries return 403 errors. Ensure the service account has read access to the specific datasets and tables you intend to query.
+{{< /admonition >}}
 
 {{< admonition type="note" >}}
 Each data source instance connects to a single GCP project. To visualize data from multiple GCP projects, create one data source per project.
@@ -71,7 +79,7 @@ To configure service account authentication:
    - **BigQuery Data Viewer** - Provides read access to BigQuery data
    - **BigQuery Job User** - Allows running BigQuery jobs
 1. Create and download a JSON key file for the service account.
-1. In the data source configuration, select **Google Service Account Key** as the authentication type.
+1. In the data source configuration, select **Google JWT File** as the authentication type.
 1. Upload the JSON key file or paste its contents.
 
 ### Google Metadata Server
@@ -86,16 +94,47 @@ When Grafana runs on a GCE virtual machine, it can automatically retrieve the de
 
 ### Service account impersonation
 
-Use [service account impersonation](https://cloud.google.com/iam/docs/service-account-impersonation) when you need to delegate access to BigQuery without distributing service account keys.
+Use [service account impersonation](https://cloud.google.com/iam/docs/service-account-impersonation) when you need to delegate access to BigQuery without distributing service account keys with broad permissions. With impersonation, the key stored in Grafana has minimal permissions — it can only generate short-lived tokens for a separate service account that has BigQuery access. This means the stored credentials cannot directly read data, reducing risk if they are compromised. This is the recommended secure authentication method for connecting Grafana Cloud to BigQuery.
 
-To configure service account impersonation:
+Service account impersonation involves two service accounts:
 
-1. Ensure the service account used by the plugin has the `iam.serviceAccounts.getAccessToken` permission. This permission is included in the [Service Account Token Creator role](https://cloud.google.com/iam/docs/roles-permissions/iam#iam.serviceAccountTokenCreator) (`roles/iam.serviceAccountTokenCreator`).
-1. Ensure the service account being impersonated has the following roles:
-   - **BigQuery Data Viewer**
-   - **BigQuery Job User**
-1. In the data source configuration, enable **Service Account Impersonation**.
-1. Enter the email address of the service account to impersonate.
+- **Authenticating service account** — The service account whose JSON key is uploaded to Grafana. This account's only permission is to create access tokens for the impersonated account. It requires the [Service Account Token Creator role](https://cloud.google.com/iam/docs/roles-permissions/iam#iam.serviceAccountTokenCreator) (`roles/iam.serviceAccountTokenCreator`).
+- **Impersonated service account** — The service account that has permissions to read data from BigQuery. Grafana assumes this account's identity to run queries. It requires the **BigQuery Data Viewer** and **BigQuery Job User** roles.
+
+#### Configure GCP permissions
+
+Before configuring the data source in Grafana, set up the required permissions in GCP. Replace `AUTH_SA`, `IMPERSONATED_SA`, and `PROJECT_ID` with your values.
+
+Grant the authenticating service account permission to create tokens for the impersonated service account:
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding \
+  IMPERSONATED_SA@PROJECT_ID.iam.gserviceaccount.com \
+  --member="serviceAccount:AUTH_SA@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator"
+```
+
+Grant the impersonated service account BigQuery access:
+
+```bash
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="serviceAccount:IMPERSONATED_SA@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/bigquery.dataViewer"
+
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="serviceAccount:IMPERSONATED_SA@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/bigquery.jobUser"
+```
+
+#### Configure the data source in Grafana
+
+To configure service account impersonation in the data source settings:
+
+1. In the **Authentication** section, select **Google JWT File** as the authentication type.
+1. Upload the JSON key file for the **authenticating** service account.
+1. Enable **Service Account Impersonation**.
+1. Enter the full email address of the **impersonated** service account.
+1. Click **Save & test** to verify the connection.
 
 ### Workload Identity Federation
 
@@ -235,6 +274,26 @@ datasources:
       usingImpersonation: true
       serviceAccountToImpersonate: <SERVICE_ACCOUNT_EMAIL>
       defaultProject: <DEFAULT_PROJECT_ID>
+```
+
+### Service account key with service account impersonation
+
+```yaml
+apiVersion: 1
+datasources:
+  - name: BigQuery
+    type: grafana-bigquery-datasource
+    editable: true
+    enabled: true
+    jsonData:
+      authenticationType: jwt
+      clientEmail: <AUTH_SERVICE_ACCOUNT_EMAIL>
+      defaultProject: <DEFAULT_PROJECT_ID>
+      tokenUri: https://oauth2.googleapis.com/token
+      usingImpersonation: true
+      serviceAccountToImpersonate: <IMPERSONATED_SERVICE_ACCOUNT_EMAIL>
+    secureJsonData:
+      privateKey: <PRIVATE_KEY>
 ```
 
 ### Workload Identity Federation

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -86,16 +86,47 @@ When Grafana runs on a GCE virtual machine, it can automatically retrieve the de
 
 ### Service account impersonation
 
-Use [service account impersonation](https://cloud.google.com/iam/docs/service-account-impersonation) when you need to delegate access to BigQuery without distributing service account keys.
+Use [service account impersonation](https://cloud.google.com/iam/docs/service-account-impersonation) when you need to delegate access to BigQuery without distributing service account keys with broad permissions. With impersonation, the key stored in Grafana has minimal permissions — it can only generate short-lived tokens for a separate service account that has BigQuery access. This means the stored credentials cannot directly read data, reducing risk if they are compromised. This is the recommended secure authentication method for connecting Grafana Cloud to BigQuery.
 
-To configure service account impersonation:
+Service account impersonation involves two service accounts:
 
-1. Ensure the service account used by the plugin has the `iam.serviceAccounts.getAccessToken` permission. This permission is included in the [Service Account Token Creator role](https://cloud.google.com/iam/docs/roles-permissions/iam#iam.serviceAccountTokenCreator) (`roles/iam.serviceAccountTokenCreator`).
-1. Ensure the service account being impersonated has the following roles:
-   - **BigQuery Data Viewer**
-   - **BigQuery Job User**
-1. In the data source configuration, enable **Service Account Impersonation**.
-1. Enter the email address of the service account to impersonate.
+- **Authenticating service account** — The service account whose JSON key is uploaded to Grafana. This account's only permission is to create access tokens for the impersonated account. It requires the [Service Account Token Creator role](https://cloud.google.com/iam/docs/roles-permissions/iam#iam.serviceAccountTokenCreator) (`roles/iam.serviceAccountTokenCreator`).
+- **Impersonated service account** — The service account that has permissions to read data from BigQuery. Grafana assumes this account's identity to run queries. It requires the **BigQuery Data Viewer** and **BigQuery Job User** roles.
+
+#### Configure GCP permissions
+
+Before configuring the data source in Grafana, set up the required permissions in GCP. Replace `AUTH_SA`, `IMPERSONATED_SA`, and `PROJECT_ID` with your values.
+
+Grant the authenticating service account permission to create tokens for the impersonated service account:
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding \
+  IMPERSONATED_SA@PROJECT_ID.iam.gserviceaccount.com \
+  --member="serviceAccount:AUTH_SA@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator"
+```
+
+Grant the impersonated service account BigQuery access:
+
+```bash
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="serviceAccount:IMPERSONATED_SA@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/bigquery.dataViewer"
+
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="serviceAccount:IMPERSONATED_SA@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/bigquery.jobUser"
+```
+
+#### Configure the data source in Grafana
+
+To configure service account impersonation in the data source settings:
+
+1. In the **Authentication** section, select **Google Service Account Key** as the authentication type.
+1. Upload the JSON key file for the **authenticating** service account.
+1. Enable **Service Account Impersonation**.
+1. Enter the full email address of the **impersonated** service account.
+1. Click **Save & test** to verify the connection.
 
 ### Forward OAuth Identity
 
@@ -195,6 +226,26 @@ datasources:
       usingImpersonation: true
       serviceAccountToImpersonate: <SERVICE_ACCOUNT_EMAIL>
       defaultProject: <DEFAULT_PROJECT_ID>
+```
+
+### Service account key with service account impersonation
+
+```yaml
+apiVersion: 1
+datasources:
+  - name: BigQuery
+    type: grafana-bigquery-datasource
+    editable: true
+    enabled: true
+    jsonData:
+      authenticationType: jwt
+      clientEmail: <AUTH_SERVICE_ACCOUNT_EMAIL>
+      defaultProject: <DEFAULT_PROJECT_ID>
+      tokenUri: https://oauth2.googleapis.com/token
+      usingImpersonation: true
+      serviceAccountToImpersonate: <IMPERSONATED_SERVICE_ACCOUNT_EMAIL>
+    secureJsonData:
+      privateKey: <PRIVATE_KEY>
 ```
 
 ### Forward OAuth Identity

--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -30,10 +30,18 @@ Before configuring the data source, ensure you have:
 
 - **Grafana version:** 11.6.0 or later (plugin version 3.x). For older Grafana versions, use plugin version 2.x (requires Grafana 10.4.8+) or 1.x.
 - **Grafana permissions:** `Organization administrator` role to add data sources.
-- **Google Cloud APIs enabled:** The following APIs must be enabled in your GCP project:
+- **Google Cloud APIs enabled:** The following APIs must be enabled on each GCP project you query:
   - [BigQuery API](https://console.cloud.google.com/apis/library/bigquery.googleapis.com)
   - [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
 - **Google Cloud credentials:** Depending on your authentication method, you need either a service account key file or access to the Google Metadata Server.
+- **Required GCP IAM roles:** The service account (or impersonated service account) must have the following roles on each project it accesses:
+  - **BigQuery Data Viewer** (`roles/bigquery.dataViewer`) — read access to BigQuery data
+  - **BigQuery Job User** (`roles/bigquery.jobUser`) — permission to run BigQuery jobs
+  - **`resourcemanager.projects.get`** permission — required for the project dropdown to populate in the query editor. This permission is included in the **Browser** role (`roles/browser`) or can be granted through a custom role.
+
+{{< admonition type="note" >}}
+If the service account has project-level access but not dataset or table-level access, **Save & test** may succeed while individual queries return 403 errors. Ensure the service account has read access to the specific datasets and tables you intend to query.
+{{< /admonition >}}
 
 {{< admonition type="note" >}}
 Each data source instance connects to a single GCP project. To visualize data from multiple GCP projects, create one data source per project.
@@ -127,6 +135,12 @@ To configure service account impersonation in the data source settings:
 1. Enable **Service Account Impersonation**.
 1. Enter the full email address of the **impersonated** service account.
 1. Click **Save & test** to verify the connection.
+
+### Workload Identity Federation
+
+[Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation) (keyless authentication) is not currently supported for Grafana Cloud. If your security requirements prohibit storing service account keys, use [service account impersonation](#service-account-impersonation) as the closest alternative — it minimizes the permissions of the stored key to only token creation.
+
+For self-managed Grafana running on GCE, you can achieve keyless authentication using the [Google Metadata Server](#google-metadata-server) method.
 
 ### Forward OAuth Identity
 

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -50,6 +50,16 @@ The query editor header includes the following options:
 | **Filter/Group/Order/Preview** | Toggle sections in the Visual query editor (Builder mode only).  |
 | **Builder/Code**               | Switch between Visual query builder and SQL code editor.         |
 
+## Query with Grafana Assistant
+
+When [Grafana Assistant](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/) is available in your Grafana instance, the query editor header displays a **Query with Assistant** button. Use it to build and refine BigQuery queries with AI assistance instead of writing SQL by hand.
+
+The Assistant uses the current query and the data source connection as context. It discovers the projects, datasets, and tables available to your data source to suggest relevant queries against your data. You can then run the generated query or continue editing it in Builder or Code mode.
+
+{{< admonition type="note" >}}
+The **Query with Assistant** button only appears when Grafana Assistant is enabled for your Grafana instance. If you don't see it, Grafana Assistant isn't available in your environment.
+{{< /admonition >}}
+
 ## SQL query editor
 
 The SQL query editor provides a rich editing experience for writing BigQuery Standard SQL queries.

--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -24,6 +24,37 @@ review_date: 2026-02-11
 
 This document provides solutions to common issues you may encounter when configuring or using the Google BigQuery data source. For configuration instructions, refer to [Configure the BigQuery data source](https://grafana.com/docs/plugins/grafana-bigquery-datasource/latest/configure/).
 
+## Plugin version errors
+
+These errors are the most common cause of issues with the BigQuery data source. Most generic error messages on **Save & test** are caused by running an outdated plugin version.
+
+### "An error occurred within the plugin" or generic plugin errors
+
+**Symptoms:**
+
+- **Save & test** fails with "An error occurred within the plugin"
+- Generic "plugin error" messages without specific details
+- Features that previously worked stop functioning after a Grafana upgrade
+
+**Solutions:**
+
+1. Update the BigQuery plugin to the latest version. In Grafana, go to **Administration** > **Plugins and data** > **Plugins**, search for BigQuery, and check for updates.
+1. Restart your Grafana instance after updating. Plugin updates may not take effect until the instance is restarted.
+1. Verify the plugin version is compatible with your Grafana version. Plugin version 3.x requires Grafana 11.6.0 or later. For older Grafana versions, use plugin version 2.x (requires Grafana 10.4.8+) or 1.x.
+
+### "Plugin not registered"
+
+**Symptoms:**
+
+- Error message indicates the plugin is not registered
+- Occurs after pod restarts in Grafana Cloud
+- Data source was previously working but becomes unavailable
+
+**Solutions:**
+
+1. Reinstall the plugin. In Grafana Cloud, go to **Administration** > **Plugins and data** > **Plugins**, find the BigQuery plugin, uninstall it, and install it again.
+1. If the issue persists after reinstalling, contact [Grafana Support](https://grafana.com/support/).
+
 ## Authentication errors
 
 These errors occur when credentials are invalid, missing, or don't have the required permissions.
@@ -44,6 +75,34 @@ These errors occur when credentials are invalid, missing, or don't have the requ
 | Service account key expired or revoked | Create a new key in the Google Cloud Console and update the data source configuration.                            |
 | Wrong project selected                 | Verify the default project matches where your data is located.                                                    |
 | API not enabled                        | Enable the [BigQuery API](https://console.cloud.google.com/apis/library/bigquery.googleapis.com) in your project. |
+| Dataset or table-level restrictions    | Grant the service account access to the specific datasets or tables, not just the project.                        |
+
+### 403 errors on queries when Save & test passes
+
+**Symptoms:**
+
+- **Save & test** succeeds but queries return 403 permission denied errors
+- Only some queries fail while others work
+
+**Solutions:**
+
+1. The service account has project-level access but is missing dataset or table-level permissions. In the BigQuery Console, verify the service account has read access to the specific datasets being queried.
+1. If querying across multiple projects, ensure the service account has the **BigQuery Data Viewer** and **BigQuery Job User** roles in each target project.
+1. Ensure the [BigQuery API](https://console.cloud.google.com/apis/library/bigquery.googleapis.com) is enabled in each target project, not just the default project.
+
+### Project dropdown not populating
+
+**Symptoms:**
+
+- The GCP project dropdown in the query editor is empty
+- No projects are listed when configuring the data source
+- Other query features work correctly
+
+**Solutions:**
+
+1. Grant the service account the `resourcemanager.projects.get` permission. This permission is included in the **Browser** role (`roles/browser`) or can be assigned through a custom role.
+1. Ensure the [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com) is enabled in the project.
+1. Verify the service account has access to the projects you expect to see listed. The dropdown only shows projects where the service account has at least one role.
 
 ### "Invalid JWT signature" or "Invalid token"
 
@@ -65,12 +124,16 @@ These errors occur when credentials are invalid, missing, or don't have the requ
 
 - Queries fail when using service account impersonation
 - Error mentions impersonation or token creation
+- Only a "Service account email to impersonate" field is visible and it's unclear how to proceed
 
 **Solutions:**
 
-1. Verify the source service account has the **Service Account Token Creator** role (`roles/iam.serviceAccountTokenCreator`).
-1. Ensure the target service account (being impersonated) has the required BigQuery roles.
-1. Check that the target service account email is correctly configured.
+1. Verify you have configured authentication *before* enabling impersonation. Service account impersonation requires an underlying authentication method (either Google JWT File or GCE Default Service Account). Upload your authenticating service account's JSON key first, then enable the impersonation checkbox.
+1. Verify the authenticating service account has the **Service Account Token Creator** role (`roles/iam.serviceAccountTokenCreator`) on the impersonated service account.
+1. Ensure the impersonated service account has the required BigQuery roles (**BigQuery Data Viewer** and **BigQuery Job User**).
+1. Check that the impersonated service account email is the full email address (for example, `my-sa@my-project.iam.gserviceaccount.com`).
+
+For detailed setup instructions including `gcloud` commands, refer to [Service account impersonation](https://grafana.com/docs/plugins/grafana-bigquery-datasource/latest/configure/#service-account-impersonation).
 
 ### Forward OAuth Identity not working
 
@@ -78,12 +141,14 @@ These errors occur when credentials are invalid, missing, or don't have the requ
 
 - Queries fail when using Forward OAuth Identity
 - User sees authentication errors after logging in
+- OAuth scopes appear correct in configuration files but authentication still fails
 
 **Solutions:**
 
 1. Verify the OAuth scopes are configured in Grafana's OAuth settings: `https://www.googleapis.com/auth/bigquery` and `https://www.googleapis.com/auth/drive` (if querying data linked to Google Drive).
 1. Ensure users have authenticated with Google OAuth before accessing BigQuery dashboards.
 1. Check that the **Default project** is configured in the data source settings.
+1. If you updated OAuth scopes in a configuration file but the data source still fails, the Grafana database may be storing stale settings that override the file-based configuration. To fix this, open the data source settings in the Grafana UI, re-enter the correct scopes, and click **Save & test**. This clears the database override.
 
 {{< admonition type="note" >}}
 Forward OAuth Identity doesn't support alerting or other background features that require credentials when users aren't logged in.
@@ -120,6 +185,75 @@ These errors occur when Grafana cannot reach Google BigQuery endpoints.
 1. Verify DNS settings on the Grafana server.
 1. Test DNS resolution: `nslookup bigquery.googleapis.com`.
 1. Check for network policy restrictions blocking external DNS.
+
+### Private data source connect (PDC) errors
+
+**Symptoms:**
+
+- "socks connect tcp ... network unreachable" error messages
+- SSH tunnel opens but closes immediately
+- Intermittent connection failures when using PDC
+- Data source works locally but fails in Grafana Cloud with PDC
+
+**Solutions:**
+
+1. Verify the PDC agent is running and connected. Check the agent logs and the PDC status in your Grafana Cloud instance under **Administration** > **Private data source connect**.
+1. Restart the PDC agent if you see "socks connect tcp ... network unreachable" errors. This error typically indicates the agent has lost its connection and needs to be restarted.
+1. Run multiple PDC agents for high availability. A single agent creates a single point of failure — if it goes down, all data sources using PDC become unavailable.
+1. If the SSH tunnel opens but immediately closes, this can indicate a plugin installation error rather than a network problem. Verify the BigQuery plugin is correctly installed and not in an error state (refer to [Plugin version errors](#plugin-version-errors)).
+1. Ensure the PDC agent's network allows outbound HTTPS (port 443) to `*.googleapis.com`.
+
+For general PDC setup and configuration, refer to [Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/).
+
+## Configuration errors
+
+These errors occur during data source setup or provisioning.
+
+### "Failed to save datasource"
+
+**Symptoms:**
+
+- Unable to save data source configuration
+- Error when clicking **Save & test**
+
+**Solutions:**
+
+1. Verify all required fields are filled in.
+1. Check that the JSON key file is valid and complete.
+1. Ensure Grafana has write permissions to its data directory.
+
+### Provisioning errors
+
+**Symptoms:**
+
+- Provisioned data source doesn't appear
+- Errors in Grafana logs about provisioning
+
+**Solutions:**
+
+1. Verify YAML syntax is correct (use a YAML validator).
+1. Check that `type` is set to `grafana-bigquery-datasource`.
+1. Ensure `authenticationType` matches the credentials provided.
+1. For `privateKey` in `secureJsonData`, ensure newlines are preserved (use `|` for multiline strings in YAML).
+
+**Example with multiline private key:**
+
+```yaml
+apiVersion: 1
+datasources:
+  - name: BigQuery
+    type: grafana-bigquery-datasource
+    jsonData:
+      authenticationType: jwt
+      clientEmail: <SERVICE_ACCOUNT_EMAIL>
+      defaultProject: <PROJECT_ID>
+      tokenUri: https://oauth2.googleapis.com/token
+    secureJsonData:
+      privateKey: |
+        -----BEGIN PRIVATE KEY-----
+        <KEY_CONTENT>
+        -----END PRIVATE KEY-----
+```
 
 ## Query errors
 
@@ -162,14 +296,20 @@ These errors occur when executing queries against BigQuery.
 
 - Query runs for a long time then fails
 - Error mentions timeout or exceeded limits
+- "context deadline exceeded" error
 
 **Solutions:**
 
+1. Increase the query timeout in the data source settings. The default timeout may not be sufficient for queries that process large volumes of data. In the data source configuration, increase the timeout value under **Additional Settings**.
 1. Narrow the time range to reduce data volume.
-1. Add filters to reduce the result set.
-1. Use partitioned tables and filter on the partition column.
-1. Add `LIMIT` clause for exploratory queries.
+1. Add partition filters. BigQuery partitioned tables perform significantly better when you filter on the partition column using `$__timeFilter`.
+1. Avoid `SELECT *` — select only the columns you need.
+1. Add a `LIMIT` clause during development and exploration.
 1. Consider pre-aggregating data for frequently-used queries.
+
+{{< admonition type="note" >}}
+Queries that process terabytes of data will likely exceed any reasonable timeout setting. In these cases, refactor the query to reduce the data scanned rather than increasing the timeout. Use partition filters, narrow the time range, or pre-aggregate data in BigQuery before querying from Grafana.
+{{< /admonition >}}
 
 ### "Query exceeded resource limits"
 
@@ -244,6 +384,20 @@ These errors occur when using template variables with the data source.
 1. Use `${variable}` syntax when the variable is adjacent to other text.
 1. Check the Query Inspector to see how variables are interpolated.
 
+### Stale variables in scheduled reports
+
+**Symptoms:**
+
+- Scheduled reports (Grafana Reporting) use outdated variable values
+- Reports always render with the same variable selection instead of refreshing dynamically
+- Variable values in the report don't match what's currently in BigQuery
+
+**Solutions:**
+
+1. Scheduled reports can cache variable values at the time the report is created. If the underlying BigQuery data changes, the report continues using the original values.
+1. To force a dynamic refresh at runtime, use the [Grafana Reporting API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/reporting/) to clear the report's saved variable configuration. Remove the `templateVars` field from the report definition so variables are evaluated fresh at each scheduled run.
+1. Alternatively, recreate the report after updating variable queries to pick up the latest values.
+
 ## Performance issues
 
 These issues relate to slow queries or high costs.
@@ -254,12 +408,16 @@ These issues relate to slow queries or high costs.
 
 - Dashboards take a long time to load
 - Queries timeout frequently
+- High bytes billed per query
 
 **Solutions:**
 
-1. Use partitioned tables and filter on partition columns with `$__timeFilter`.
-1. Select only the columns you need instead of `SELECT *`.
-1. Use appropriate aggregation intervals to reduce data points.
+1. **Use partition filters.** Always filter on the partition column using `$__timeFilter(partition_column)`. Without a partition filter, BigQuery scans the entire table regardless of the dashboard time range.
+1. **Narrow the time range.** Shorter time ranges scan less data. Use the dashboard time picker to limit the window.
+1. **Avoid `SELECT *`.** Select only the columns your visualization needs. BigQuery is columnar, so fewer columns means less data scanned.
+1. **Add `LIMIT` during development.** Use `LIMIT` when building and testing queries to reduce scan costs.
+1. **Use appropriate aggregation intervals.** Aggregate data to match the visualization granularity — there's no benefit in returning per-second data for a chart showing daily trends.
+1. **Set `Max bytes billed`.** Configure this in **Additional Settings** to prevent unexpectedly expensive queries from running.
 1. Consider using BigQuery BI Engine for frequently accessed data.
 
 ### High query costs
@@ -294,55 +452,44 @@ These issues relate to slow queries or high costs.
 The Storage API doesn't work with Forward OAuth Identity authentication.
 {{< /admonition >}}
 
-## Configuration errors
+## Grafana Cloud vs. self-hosted differences
 
-These errors occur during data source setup or provisioning.
+If you are migrating from self-hosted Grafana to Grafana Cloud, be aware of the following behavioral differences with the BigQuery plugin.
 
-### "Failed to save datasource"
+### Dataset and table browsing
 
-**Symptoms:**
+On self-hosted Grafana, the BigQuery plugin connects directly to Google Cloud APIs. On Grafana Cloud, the connection may route through [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) if your BigQuery resources are not publicly accessible. This can affect:
 
-- Unable to save data source configuration
-- Error when clicking **Save & test**
+- The speed at which datasets and tables load in the query editor dropdowns
+- Whether all projects are visible in the project selector (ensure the service account has `resourcemanager.projects.get` on each project)
 
-**Solutions:**
+If dataset browsing works on self-hosted but not on Grafana Cloud, verify your PDC agent is running and that the service account permissions are identical between environments.
 
-1. Verify all required fields are filled in.
-1. Check that the JSON key file is valid and complete.
-1. Ensure Grafana has write permissions to its data directory.
+### Query variable substitution
 
-### Provisioning errors
+Template variable substitution behavior is consistent between self-hosted and Grafana Cloud. If you observe differences after migration, check:
 
-**Symptoms:**
+1. The plugin version matches between environments. Older plugin versions may handle multi-value variables differently.
+1. The data source configuration is identical — particularly the **Default project** and **Processing location** settings.
+1. Variable queries that rely on `$__interval` or time-range macros may produce different results if the default dashboard time range differs between environments.
 
-- Provisioned data source doesn't appear
-- Errors in Grafana logs about provisioning
+## Auditing and usage tracking
 
-**Solutions:**
+To track which Grafana users are running BigQuery queries:
 
-1. Verify YAML syntax is correct (use a YAML validator).
-1. Check that `type` is set to `grafana-bigquery-datasource`.
-1. Ensure `authenticationType` matches the credentials provided.
-1. For `privateKey` in `secureJsonData`, ensure newlines are preserved (use `|` for multiline strings in YAML).
+- **Grafana audit logging** (available in Grafana Enterprise and Grafana Cloud) can identify the user and data source associated with a query request, but does not log the specific SQL query text or which BigQuery tables were accessed. For details, refer to [Auditing](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-security/audit-grafana/).
+- **BigQuery audit logs** in GCP provide full query-level detail, including the SQL text, tables accessed, bytes scanned, and job metadata. Enable [Cloud Audit Logs for BigQuery](https://cloud.google.com/bigquery/docs/reference/auditlogs) to capture this information.
 
-**Example with multiline private key:**
+For complete query-level auditing, use BigQuery's audit logs. You can correlate them with Grafana audit logs by matching timestamps and the service account identity.
 
-```yaml
-apiVersion: 1
-datasources:
-  - name: BigQuery
-    type: grafana-bigquery-datasource
-    jsonData:
-      authenticationType: jwt
-      clientEmail: <SERVICE_ACCOUNT_EMAIL>
-      defaultProject: <PROJECT_ID>
-      tokenUri: https://oauth2.googleapis.com/token
-    secureJsonData:
-      privateKey: |
-        -----BEGIN PRIVATE KEY-----
-        <KEY_CONTENT>
-        -----END PRIVATE KEY-----
-```
+## BigQuery metrics in Google Cloud Monitoring
+
+If you use Google Cloud Monitoring to track BigQuery usage metrics (such as `bigquery.googleapis.com/query/count` or `bigquery.googleapis.com/query/execution_times`), be aware that GCP attributes these metrics to the project that *runs* the query job, not the project that *hosts* the data. This means:
+
+- If your Grafana service account runs jobs in Project A but queries data in Project B, the metrics appear under Project A.
+- This is standard [GCP metric attribution behavior](https://cloud.google.com/bigquery/docs/monitoring), not something controlled by the Grafana plugin.
+
+When building Cloud Monitoring dashboards for BigQuery usage, filter by the project configured as the **Default project** in the BigQuery data source settings (or the project specified in the `$__timeFilter` query), as that is where job metrics are attributed.
 
 ## Enable debug logging
 

--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -205,6 +205,56 @@ These errors occur when Grafana cannot reach Google BigQuery endpoints.
 
 For general PDC setup and configuration, refer to [Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/).
 
+## Configuration errors
+
+These errors occur during data source setup or provisioning.
+
+### "Failed to save datasource"
+
+**Symptoms:**
+
+- Unable to save data source configuration
+- Error when clicking **Save & test**
+
+**Solutions:**
+
+1. Verify all required fields are filled in.
+1. Check that the JSON key file is valid and complete.
+1. Ensure Grafana has write permissions to its data directory.
+
+### Provisioning errors
+
+**Symptoms:**
+
+- Provisioned data source doesn't appear
+- Errors in Grafana logs about provisioning
+
+**Solutions:**
+
+1. Verify YAML syntax is correct (use a YAML validator).
+1. Check that `type` is set to `grafana-bigquery-datasource`.
+1. Ensure `authenticationType` matches the credentials provided.
+1. For `privateKey` in `secureJsonData`, ensure newlines are preserved (use `|` for multiline strings in YAML).
+
+**Example with multiline private key:**
+
+```yaml
+apiVersion: 1
+datasources:
+  - name: BigQuery
+    type: grafana-bigquery-datasource
+    jsonData:
+      authenticationType: jwt
+      clientEmail: <SERVICE_ACCOUNT_EMAIL>
+      defaultProject: <PROJECT_ID>
+      tokenUri: https://oauth2.googleapis.com/token
+    secureJsonData:
+      privateKey: |
+        -----BEGIN PRIVATE KEY-----
+        <KEY_CONTENT>
+        -----END PRIVATE KEY-----
+```
+
 ## Query errors
 
 These errors occur when executing queries against BigQuery.
@@ -348,27 +398,6 @@ These errors occur when using template variables with the data source.
 1. To force a dynamic refresh at runtime, use the [Grafana Reporting API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/reporting/) to clear the report's saved variable configuration. Remove the `templateVars` field from the report definition so variables are evaluated fresh at each scheduled run.
 1. Alternatively, recreate the report after updating variable queries to pick up the latest values.
 
-## Grafana Cloud vs. self-hosted differences
-
-If you are migrating from self-hosted Grafana to Grafana Cloud, be aware of the following behavioral differences with the BigQuery plugin.
-
-### Dataset and table browsing
-
-On self-hosted Grafana, the BigQuery plugin connects directly to Google Cloud APIs. On Grafana Cloud, the connection may route through [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) if your BigQuery resources are not publicly accessible. This can affect:
-
-- The speed at which datasets and tables load in the query editor dropdowns
-- Whether all projects are visible in the project selector (ensure the service account has `resourcemanager.projects.get` on each project)
-
-If dataset browsing works on self-hosted but not on Grafana Cloud, verify your PDC agent is running and that the service account permissions are identical between environments.
-
-### Query variable substitution
-
-Template variable substitution behavior is consistent between self-hosted and Grafana Cloud. If you observe differences after migration, check:
-
-1. The plugin version matches between environments. Older plugin versions may handle multi-value variables differently.
-1. The data source configuration is identical — particularly the **Default project** and **Processing location** settings.
-1. Variable queries that rely on `$__interval` or time-range macros may produce different results if the default dashboard time range differs between environments.
-
 ## Performance issues
 
 These issues relate to slow queries or high costs.
@@ -423,55 +452,44 @@ These issues relate to slow queries or high costs.
 The Storage API doesn't work with Forward OAuth Identity authentication.
 {{< /admonition >}}
 
-## Configuration errors
+## Grafana Cloud vs. self-hosted differences
 
-These errors occur during data source setup or provisioning.
+If you are migrating from self-hosted Grafana to Grafana Cloud, be aware of the following behavioral differences with the BigQuery plugin.
 
-### "Failed to save datasource"
+### Dataset and table browsing
 
-**Symptoms:**
+On self-hosted Grafana, the BigQuery plugin connects directly to Google Cloud APIs. On Grafana Cloud, the connection may route through [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) if your BigQuery resources are not publicly accessible. This can affect:
 
-- Unable to save data source configuration
-- Error when clicking **Save & test**
+- The speed at which datasets and tables load in the query editor dropdowns
+- Whether all projects are visible in the project selector (ensure the service account has `resourcemanager.projects.get` on each project)
 
-**Solutions:**
+If dataset browsing works on self-hosted but not on Grafana Cloud, verify your PDC agent is running and that the service account permissions are identical between environments.
 
-1. Verify all required fields are filled in.
-1. Check that the JSON key file is valid and complete.
-1. Ensure Grafana has write permissions to its data directory.
+### Query variable substitution
 
-### Provisioning errors
+Template variable substitution behavior is consistent between self-hosted and Grafana Cloud. If you observe differences after migration, check:
 
-**Symptoms:**
+1. The plugin version matches between environments. Older plugin versions may handle multi-value variables differently.
+1. The data source configuration is identical — particularly the **Default project** and **Processing location** settings.
+1. Variable queries that rely on `$__interval` or time-range macros may produce different results if the default dashboard time range differs between environments.
 
-- Provisioned data source doesn't appear
-- Errors in Grafana logs about provisioning
+## Auditing and usage tracking
 
-**Solutions:**
+To track which Grafana users are running BigQuery queries:
 
-1. Verify YAML syntax is correct (use a YAML validator).
-1. Check that `type` is set to `grafana-bigquery-datasource`.
-1. Ensure `authenticationType` matches the credentials provided.
-1. For `privateKey` in `secureJsonData`, ensure newlines are preserved (use `|` for multiline strings in YAML).
+- **Grafana audit logging** (available in Grafana Enterprise and Grafana Cloud) can identify the user and data source associated with a query request, but does not log the specific SQL query text or which BigQuery tables were accessed. For details, refer to [Auditing](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-security/audit-grafana/).
+- **BigQuery audit logs** in GCP provide full query-level detail, including the SQL text, tables accessed, bytes scanned, and job metadata. Enable [Cloud Audit Logs for BigQuery](https://cloud.google.com/bigquery/docs/reference/auditlogs) to capture this information.
 
-**Example with multiline private key:**
+For complete query-level auditing, use BigQuery's audit logs. You can correlate them with Grafana audit logs by matching timestamps and the service account identity.
 
-```yaml
-apiVersion: 1
-datasources:
-  - name: BigQuery
-    type: grafana-bigquery-datasource
-    jsonData:
-      authenticationType: jwt
-      clientEmail: <SERVICE_ACCOUNT_EMAIL>
-      defaultProject: <PROJECT_ID>
-      tokenUri: https://oauth2.googleapis.com/token
-    secureJsonData:
-      privateKey: |
-        -----BEGIN PRIVATE KEY-----
-        <KEY_CONTENT>
-        -----END PRIVATE KEY-----
-```
+## BigQuery metrics in Google Cloud Monitoring
+
+If you use Google Cloud Monitoring to track BigQuery usage metrics (such as `bigquery.googleapis.com/query/count` or `bigquery.googleapis.com/query/execution_times`), be aware that GCP attributes these metrics to the project that *runs* the query job, not the project that *hosts* the data. This means:
+
+- If your Grafana service account runs jobs in Project A but queries data in Project B, the metrics appear under Project A.
+- This is standard [GCP metric attribution behavior](https://cloud.google.com/bigquery/docs/monitoring), not something controlled by the Grafana plugin.
+
+When building Cloud Monitoring dashboards for BigQuery usage, filter by the project configured as the **Default project** in the BigQuery data source settings (or the project specified in the `$__timeFilter` query), as that is where job metrics are attributed.
 
 ## Enable debug logging
 
@@ -498,24 +516,6 @@ The Query Inspector helps debug query issues:
 1. Review the **Query** tab to see the exact SQL sent to BigQuery.
 1. Check the **Stats** tab for query timing information.
 1. Look at the **JSON** tab for the raw response data.
-
-## Auditing and usage tracking
-
-To track which Grafana users are running BigQuery queries:
-
-- **Grafana audit logging** (available in Grafana Enterprise and Grafana Cloud) can identify the user and data source associated with a query request, but does not log the specific SQL query text or which BigQuery tables were accessed. For details, refer to [Auditing](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-security/audit-grafana/).
-- **BigQuery audit logs** in GCP provide full query-level detail, including the SQL text, tables accessed, bytes scanned, and job metadata. Enable [Cloud Audit Logs for BigQuery](https://cloud.google.com/bigquery/docs/reference/auditlogs) to capture this information.
-
-For complete query-level auditing, use BigQuery's audit logs. You can correlate them with Grafana audit logs by matching timestamps and the service account identity.
-
-## BigQuery metrics in Google Cloud Monitoring
-
-If you use Google Cloud Monitoring to track BigQuery usage metrics (such as `bigquery.googleapis.com/query/count` or `bigquery.googleapis.com/query/execution_times`), be aware that GCP attributes these metrics to the project that *runs* the query job, not the project that *hosts* the data. This means:
-
-- If your Grafana service account runs jobs in Project A but queries data in Project B, the metrics appear under Project A.
-- This is standard [GCP metric attribution behavior](https://cloud.google.com/bigquery/docs/monitoring), not something controlled by the Grafana plugin.
-
-When building Cloud Monitoring dashboards for BigQuery usage, filter by the project configured as the **Default project** in the BigQuery data source settings (or the project specified in the `$__timeFilter` query), as that is where job metrics are attributed.
 
 ## Get additional help
 

--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -484,10 +484,9 @@ If you are migrating from self-hosted Grafana to Grafana Cloud, be aware of the 
 
 ### Dataset and table browsing
 
-On self-hosted Grafana, the BigQuery plugin connects directly to Google Cloud APIs. On Grafana Cloud, the connection may route through [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) if your BigQuery resources are not publicly accessible. This can affect:
+On self-hosted Grafana, the BigQuery plugin connects directly to Google Cloud APIs. On Grafana Cloud, the connection may route through [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) if your BigQuery resources are not publicly accessible. This routing can affect the speed at which datasets and tables load in the query editor dropdowns.
 
-- The speed at which datasets and tables load in the query editor dropdowns
-- Whether all projects are visible in the project selector (ensure the service account has `resourcemanager.projects.get` on each project)
+Whether all projects are visible in the project selector depends on service account permissions rather than PDC. Ensure the service account has `resourcemanager.projects.get` on each project you expect to see listed.
 
 If dataset browsing works on self-hosted but not on Grafana Cloud, verify your PDC agent is running and that the service account permissions are identical between environments.
 

--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -9,6 +9,7 @@ keywords:
   - errors
   - authentication
   - query
+  - workload identity federation
 labels:
   products:
     - cloud
@@ -134,6 +135,31 @@ These errors occur when credentials are invalid, missing, or don't have the requ
 1. Check that the impersonated service account email is the full email address (for example, `my-sa@my-project.iam.gserviceaccount.com`).
 
 For detailed setup instructions including `gcloud` commands, refer to [Service account impersonation](https://grafana.com/docs/plugins/grafana-bigquery-datasource/latest/configure/#service-account-impersonation).
+
+### Workload Identity Federation authentication failing
+
+**Symptoms:**
+
+- Queries fail when using Workload Identity Federation (WIF)
+- Errors mention token exchange, invalid audience, or the workload identity pool provider
+- The project, dataset, or table selectors in the query editor show load errors because the default project can't be resolved
+- Authentication works on interactive dashboards but fails for alerts, scheduled reports, or public dashboards
+
+**Solutions:**
+
+1. Confirm you're on Grafana Cloud. Workload Identity Federation is available on Grafana Cloud only, because Grafana Cloud exchanges the signed-in user's external OIDC token for a short-lived Google Cloud access token before the request reaches the plugin.
+1. Verify the **Workload Identity Pool Provider** resource path is correct and uses the format `projects/<project-number>/locations/global/workloadIdentityPools/<pool-id>/providers/<provider-id>`. Use the project **number** (a numeric ID such as `123456789`), not the project ID (such as `my-project`).
+1. Check the provider's attribute mappings in Google Cloud. The `google.subject` attribute must map to the correct claim from your identity provider (for example, `assertion.sub` — the exact mapping depends on your provider's claim format).
+1. Verify the BigQuery permissions are granted to the correct principal:
+   - **Without impersonation** — the WIF pool principal needs the **BigQuery Data Viewer** and **BigQuery Job User** roles, and the **Service account email** field must be left blank.
+   - **With impersonation** — the impersonated service account needs the **BigQuery Data Viewer** and **BigQuery Job User** roles, the WIF pool principal needs the **Service Account Token Creator** role on that service account, and the impersonated service account's full email must be entered in the **Service account email** field.
+1. Ensure your Grafana Cloud stack's SSO integration is configured against the same OIDC provider that the workload identity pool trusts. If the signed-in user's identity isn't available, Grafana Cloud can't exchange it for a Google Cloud access token.
+
+{{< admonition type="note" >}}
+Credentials from Workload Identity Federation are tied to the signed-in user's active session — there is no long-lived credential available to the Grafana backend. This means any feature that runs without a user present will not work, including alerting, scheduled reports, and public dashboards. If you rely on these features, use a service account key (JWT) instead.
+{{< /admonition >}}
+
+For detailed setup instructions, refer to [Workload Identity Federation](https://grafana.com/docs/plugins/grafana-bigquery-datasource/latest/configure/#workload-identity-federation).
 
 ### Forward OAuth Identity not working
 

--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -174,7 +174,7 @@ For detailed setup instructions, refer to [Workload Identity Federation](https:/
 1. Verify the OAuth scopes are configured in Grafana's OAuth settings: `https://www.googleapis.com/auth/bigquery` and `https://www.googleapis.com/auth/drive` (if querying data linked to Google Drive).
 1. Ensure users have authenticated with Google OAuth before accessing BigQuery dashboards.
 1. Check that the **Default project** is configured in the data source settings.
-1. If you updated OAuth scopes in a configuration file but the data source still fails, the Grafana database may be storing stale settings that override the file-based configuration. To fix this, open the data source settings in the Grafana UI, re-enter the correct scopes, and click **Save & test**. This clears the database override.
+1. If you updated OAuth scopes in a configuration file but the data source still fails, the Grafana database may be storing stale settings that override the file-based configuration. To fix this, open the data source settings in the Grafana UI, re-enter the correct scopes, and click **Save & test**.
 
 {{< admonition type="note" >}}
 Forward OAuth Identity doesn't support alerting or other background features that require credentials when users aren't logged in.

--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -24,6 +24,37 @@ review_date: 2026-02-11
 
 This document provides solutions to common issues you may encounter when configuring or using the Google BigQuery data source. For configuration instructions, refer to [Configure the BigQuery data source](https://grafana.com/docs/plugins/grafana-bigquery-datasource/latest/configure/).
 
+## Plugin version errors
+
+These errors are the most common cause of issues with the BigQuery data source. Most generic error messages on **Save & test** are caused by running an outdated plugin version.
+
+### "An error occurred within the plugin" or generic plugin errors
+
+**Symptoms:**
+
+- **Save & test** fails with "An error occurred within the plugin"
+- Generic "plugin error" messages without specific details
+- Features that previously worked stop functioning after a Grafana upgrade
+
+**Solutions:**
+
+1. Update the BigQuery plugin to the latest version. In Grafana, go to **Administration** > **Plugins and data** > **Plugins**, search for BigQuery, and check for updates.
+1. Restart your Grafana instance after updating. Plugin updates may not take effect until the instance is restarted.
+1. Verify the plugin version is compatible with your Grafana version. Plugin version 3.x requires Grafana 11.6.0 or later. For older Grafana versions, use plugin version 2.x (requires Grafana 10.4.8+) or 1.x.
+
+### "Plugin not registered"
+
+**Symptoms:**
+
+- Error message indicates the plugin is not registered
+- Occurs after pod restarts in Grafana Cloud
+- Data source was previously working but becomes unavailable
+
+**Solutions:**
+
+1. Reinstall the plugin. In Grafana Cloud, go to **Administration** > **Plugins and data** > **Plugins**, find the BigQuery plugin, uninstall it, and install it again.
+1. If the issue persists after reinstalling, contact [Grafana Support](https://grafana.com/support/).
+
 ## Authentication errors
 
 These errors occur when credentials are invalid, missing, or don't have the required permissions.
@@ -44,6 +75,34 @@ These errors occur when credentials are invalid, missing, or don't have the requ
 | Service account key expired or revoked | Create a new key in the Google Cloud Console and update the data source configuration.                            |
 | Wrong project selected                 | Verify the default project matches where your data is located.                                                    |
 | API not enabled                        | Enable the [BigQuery API](https://console.cloud.google.com/apis/library/bigquery.googleapis.com) in your project. |
+| Dataset or table-level restrictions    | Grant the service account access to the specific datasets or tables, not just the project.                        |
+
+### 403 errors on queries when Save & test passes
+
+**Symptoms:**
+
+- **Save & test** succeeds but queries return 403 permission denied errors
+- Only some queries fail while others work
+
+**Solutions:**
+
+1. The service account has project-level access but is missing dataset or table-level permissions. In the BigQuery Console, verify the service account has read access to the specific datasets being queried.
+1. If querying across multiple projects, ensure the service account has the **BigQuery Data Viewer** and **BigQuery Job User** roles in each target project.
+1. Ensure the [BigQuery API](https://console.cloud.google.com/apis/library/bigquery.googleapis.com) is enabled in each target project, not just the default project.
+
+### Project dropdown not populating
+
+**Symptoms:**
+
+- The GCP project dropdown in the query editor is empty
+- No projects are listed when configuring the data source
+- Other query features work correctly
+
+**Solutions:**
+
+1. Grant the service account the `resourcemanager.projects.get` permission. This permission is included in the **Browser** role (`roles/browser`) or can be assigned through a custom role.
+1. Ensure the [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com) is enabled in the project.
+1. Verify the service account has access to the projects you expect to see listed. The dropdown only shows projects where the service account has at least one role.
 
 ### "Invalid JWT signature" or "Invalid token"
 
@@ -65,12 +124,16 @@ These errors occur when credentials are invalid, missing, or don't have the requ
 
 - Queries fail when using service account impersonation
 - Error mentions impersonation or token creation
+- Only a "Service account email to impersonate" field is visible and it's unclear how to proceed
 
 **Solutions:**
 
-1. Verify the source service account has the **Service Account Token Creator** role (`roles/iam.serviceAccountTokenCreator`).
-1. Ensure the target service account (being impersonated) has the required BigQuery roles.
-1. Check that the target service account email is correctly configured.
+1. Verify you have configured authentication *before* enabling impersonation. Service account impersonation requires an underlying authentication method (either Google Service Account Key or Google Metadata Server). Upload your authenticating service account's JSON key first, then enable the impersonation checkbox.
+1. Verify the authenticating service account has the **Service Account Token Creator** role (`roles/iam.serviceAccountTokenCreator`) on the impersonated service account.
+1. Ensure the impersonated service account has the required BigQuery roles (**BigQuery Data Viewer** and **BigQuery Job User**).
+1. Check that the impersonated service account email is the full email address (for example, `my-sa@my-project.iam.gserviceaccount.com`).
+
+For detailed setup instructions including `gcloud` commands, refer to [Service account impersonation](https://grafana.com/docs/plugins/grafana-bigquery-datasource/latest/configure/#service-account-impersonation).
 
 ### Forward OAuth Identity not working
 
@@ -78,12 +141,14 @@ These errors occur when credentials are invalid, missing, or don't have the requ
 
 - Queries fail when using Forward OAuth Identity
 - User sees authentication errors after logging in
+- OAuth scopes appear correct in configuration files but authentication still fails
 
 **Solutions:**
 
 1. Verify the OAuth scopes are configured in Grafana's OAuth settings: `https://www.googleapis.com/auth/bigquery` and `https://www.googleapis.com/auth/drive` (if querying data linked to Google Drive).
 1. Ensure users have authenticated with Google OAuth before accessing BigQuery dashboards.
 1. Check that the **Default project** is configured in the data source settings.
+1. If you updated OAuth scopes in a configuration file but the data source still fails, the Grafana database may be storing stale settings that override the file-based configuration. To fix this, open the data source settings in the Grafana UI, re-enter the correct scopes, and click **Save & test**. This clears the database override.
 
 {{< admonition type="note" >}}
 Forward OAuth Identity doesn't support alerting or other background features that require credentials when users aren't logged in.
@@ -120,6 +185,25 @@ These errors occur when Grafana cannot reach Google BigQuery endpoints.
 1. Verify DNS settings on the Grafana server.
 1. Test DNS resolution: `nslookup bigquery.googleapis.com`.
 1. Check for network policy restrictions blocking external DNS.
+
+### Private data source connect (PDC) errors
+
+**Symptoms:**
+
+- "socks connect tcp ... network unreachable" error messages
+- SSH tunnel opens but closes immediately
+- Intermittent connection failures when using PDC
+- Data source works locally but fails in Grafana Cloud with PDC
+
+**Solutions:**
+
+1. Verify the PDC agent is running and connected. Check the agent logs and the PDC status in your Grafana Cloud instance under **Administration** > **Private data source connect**.
+1. Restart the PDC agent if you see "socks connect tcp ... network unreachable" errors. This error typically indicates the agent has lost its connection and needs to be restarted.
+1. Run multiple PDC agents for high availability. A single agent creates a single point of failure — if it goes down, all data sources using PDC become unavailable.
+1. If the SSH tunnel opens but immediately closes, this can indicate a plugin installation error rather than a network problem. Verify the BigQuery plugin is correctly installed and not in an error state (refer to [Plugin version errors](#plugin-version-errors)).
+1. Ensure the PDC agent's network allows outbound HTTPS (port 443) to `*.googleapis.com`.
+
+For general PDC setup and configuration, refer to [Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/).
 
 ## Query errors
 
@@ -162,14 +246,20 @@ These errors occur when executing queries against BigQuery.
 
 - Query runs for a long time then fails
 - Error mentions timeout or exceeded limits
+- "context deadline exceeded" error
 
 **Solutions:**
 
+1. Increase the query timeout in the data source settings. The default timeout may not be sufficient for queries that process large volumes of data. In the data source configuration, increase the timeout value under **Additional Settings**.
 1. Narrow the time range to reduce data volume.
-1. Add filters to reduce the result set.
-1. Use partitioned tables and filter on the partition column.
-1. Add `LIMIT` clause for exploratory queries.
+1. Add partition filters. BigQuery partitioned tables perform significantly better when you filter on the partition column using `$__timeFilter`.
+1. Avoid `SELECT *` — select only the columns you need.
+1. Add a `LIMIT` clause during development and exploration.
 1. Consider pre-aggregating data for frequently-used queries.
+
+{{< admonition type="note" >}}
+Queries that process terabytes of data will likely exceed any reasonable timeout setting. In these cases, refactor the query to reduce the data scanned rather than increasing the timeout. Use partition filters, narrow the time range, or pre-aggregate data in BigQuery before querying from Grafana.
+{{< /admonition >}}
 
 ### "Query exceeded resource limits"
 
@@ -244,6 +334,41 @@ These errors occur when using template variables with the data source.
 1. Use `${variable}` syntax when the variable is adjacent to other text.
 1. Check the Query Inspector to see how variables are interpolated.
 
+### Stale variables in scheduled reports
+
+**Symptoms:**
+
+- Scheduled reports (Grafana Reporting) use outdated variable values
+- Reports always render with the same variable selection instead of refreshing dynamically
+- Variable values in the report don't match what's currently in BigQuery
+
+**Solutions:**
+
+1. Scheduled reports can cache variable values at the time the report is created. If the underlying BigQuery data changes, the report continues using the original values.
+1. To force a dynamic refresh at runtime, use the [Grafana Reporting API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/reporting/) to clear the report's saved variable configuration. Remove the `templateVars` field from the report definition so variables are evaluated fresh at each scheduled run.
+1. Alternatively, recreate the report after updating variable queries to pick up the latest values.
+
+## Grafana Cloud vs. self-hosted differences
+
+If you are migrating from self-hosted Grafana to Grafana Cloud, be aware of the following behavioral differences with the BigQuery plugin.
+
+### Dataset and table browsing
+
+On self-hosted Grafana, the BigQuery plugin connects directly to Google Cloud APIs. On Grafana Cloud, the connection may route through [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) if your BigQuery resources are not publicly accessible. This can affect:
+
+- The speed at which datasets and tables load in the query editor dropdowns
+- Whether all projects are visible in the project selector (ensure the service account has `resourcemanager.projects.get` on each project)
+
+If dataset browsing works on self-hosted but not on Grafana Cloud, verify your PDC agent is running and that the service account permissions are identical between environments.
+
+### Query variable substitution
+
+Template variable substitution behavior is consistent between self-hosted and Grafana Cloud. If you observe differences after migration, check:
+
+1. The plugin version matches between environments. Older plugin versions may handle multi-value variables differently.
+1. The data source configuration is identical — particularly the **Default project** and **Processing location** settings.
+1. Variable queries that rely on `$__interval` or time-range macros may produce different results if the default dashboard time range differs between environments.
+
 ## Performance issues
 
 These issues relate to slow queries or high costs.
@@ -254,12 +379,16 @@ These issues relate to slow queries or high costs.
 
 - Dashboards take a long time to load
 - Queries timeout frequently
+- High bytes billed per query
 
 **Solutions:**
 
-1. Use partitioned tables and filter on partition columns with `$__timeFilter`.
-1. Select only the columns you need instead of `SELECT *`.
-1. Use appropriate aggregation intervals to reduce data points.
+1. **Use partition filters.** Always filter on the partition column using `$__timeFilter(partition_column)`. Without a partition filter, BigQuery scans the entire table regardless of the dashboard time range.
+1. **Narrow the time range.** Shorter time ranges scan less data. Use the dashboard time picker to limit the window.
+1. **Avoid `SELECT *`.** Select only the columns your visualization needs. BigQuery is columnar, so fewer columns means less data scanned.
+1. **Add `LIMIT` during development.** Use `LIMIT` when building and testing queries to reduce scan costs.
+1. **Use appropriate aggregation intervals.** Aggregate data to match the visualization granularity — there's no benefit in returning per-second data for a chart showing daily trends.
+1. **Set `Max bytes billed`.** Configure this in **Additional Settings** to prevent unexpectedly expensive queries from running.
 1. Consider using BigQuery BI Engine for frequently accessed data.
 
 ### High query costs
@@ -369,6 +498,24 @@ The Query Inspector helps debug query issues:
 1. Review the **Query** tab to see the exact SQL sent to BigQuery.
 1. Check the **Stats** tab for query timing information.
 1. Look at the **JSON** tab for the raw response data.
+
+## Auditing and usage tracking
+
+To track which Grafana users are running BigQuery queries:
+
+- **Grafana audit logging** (available in Grafana Enterprise and Grafana Cloud) can identify the user and data source associated with a query request, but does not log the specific SQL query text or which BigQuery tables were accessed. For details, refer to [Auditing](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-security/audit-grafana/).
+- **BigQuery audit logs** in GCP provide full query-level detail, including the SQL text, tables accessed, bytes scanned, and job metadata. Enable [Cloud Audit Logs for BigQuery](https://cloud.google.com/bigquery/docs/reference/auditlogs) to capture this information.
+
+For complete query-level auditing, use BigQuery's audit logs. You can correlate them with Grafana audit logs by matching timestamps and the service account identity.
+
+## BigQuery metrics in Google Cloud Monitoring
+
+If you use Google Cloud Monitoring to track BigQuery usage metrics (such as `bigquery.googleapis.com/query/count` or `bigquery.googleapis.com/query/execution_times`), be aware that GCP attributes these metrics to the project that *runs* the query job, not the project that *hosts* the data. This means:
+
+- If your Grafana service account runs jobs in Project A but queries data in Project B, the metrics appear under Project A.
+- This is standard [GCP metric attribution behavior](https://cloud.google.com/bigquery/docs/monitoring), not something controlled by the Grafana plugin.
+
+When building Cloud Monitoring dashboards for BigQuery usage, filter by the project configured as the **Default project** in the BigQuery data source settings (or the project specified in the `$__timeFilter` query), as that is where job metrics are attributed.
 
 ## Get additional help
 

--- a/docs/sources/troubleshooting.md
+++ b/docs/sources/troubleshooting.md
@@ -300,7 +300,7 @@ These errors occur when executing queries against BigQuery.
 
 **Solutions:**
 
-1. Increase the query timeout in the data source settings. The default timeout may not be sufficient for queries that process large volumes of data. In the data source configuration, increase the timeout value under **Additional Settings**.
+1. Reduce the amount of data your query scans. There is no configurable query timeout in the BigQuery data source settings — the timeout is determined by BigQuery's server-side limits and the Grafana instance's global query timeout.
 1. Narrow the time range to reduce data volume.
 1. Add partition filters. BigQuery partitioned tables perform significantly better when you filter on the partition column using `$__timeFilter`.
 1. Avoid `SELECT *` — select only the columns you need.


### PR DESCRIPTION
Expands the BigQuery data source documentation based on findings from a Zendesk case review and a support escalation issue. The changes address the most common support themes and fill gaps in the existing docs.

configure.md
Expanded service account impersonation section with security rationale, two-account mental model, gcloud CLI examples, and step-by-step Grafana UI instructions
Added a complete IAM permissions checklist (including resourcemanager.projects.get) to the "Before you begin" section
Added a note that Workload Identity Federation is not supported for Grafana Cloud
Added a provisioning example for JWT + service account impersonation
Documented the Forward OAuth Identity DB override gotcha
troubleshooting.md
Added "Plugin version errors" section (most frequent support issue) covering outdated plugin and "plugin not registered" errors
Added 403 errors when Save & test passes, project dropdown not populating, and PDC-specific troubleshooting
Expanded query timeout section with timeout configuration and terabyte-scale query guidance
Added stale variables in scheduled reports
Added Grafana Cloud vs. self-hosted differences section
Added auditing/usage tracking and BigQuery metrics attribution sections
Reordered the entire document to follow a logical user journey (install, authenticate, connect, configure, query, optimize)

Addresses this Support escalation issue:  https://github.com/grafana/support-escalations/issues/20473