### PR TITLE
fix: honor month multiplier in $__timeGroup and guard empty interval

### DIFF
--- a/.changeset/timegroup-month-multiplier.md
+++ b/.changeset/timegroup-month-multiplier.md
@@ -1,0 +1,5 @@
+---
+'grafana-bigquery-datasource': patch
+---
+
+Fix: `$__timeGroup` now honors the multiplier for month intervals — `3M`, `6M`, `12M` produce N-month buckets aligned to the calendar year instead of always grouping by a single month. It also no longer panics on an empty or quote-only interval (e.g. `''`), returning a clear error instead.

--- a/pkg/bigquery/macros.go
+++ b/pkg/bigquery/macros.go
@@ -3,6 +3,7 @@ package bigquery
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
@@ -33,11 +34,30 @@ func macroTimeGroup(query *sqlutil.Query, args []string) (string, error) {
 
 	timeVar := args[0]
 	intervalVar := strings.Trim(args[1], "'\"")
-	last := intervalVar[len(intervalVar)-1:]
+	if intervalVar == "" {
+		return "", fmt.Errorf("the second parameter(interval) for $__timeGroup macro cannot be empty")
+	}
 
-	// when month interval
-	if last == "M" {
-		return fmt.Sprintf("TIMESTAMP((PARSE_DATE(\"%%Y-%%m-%%d\",CONCAT( CAST((EXTRACT(YEAR FROM %s)) AS STRING),'-',CAST((EXTRACT(MONTH FROM %s)) AS STRING),'-','01'))))", timeVar, timeVar), nil
+	// Month intervals need calendar-aware grouping because a month is not a fixed
+	// number of milliseconds. The trailing "M" denotes months, e.g. "1M", "3M".
+	if strings.HasSuffix(intervalVar, "M") {
+		months := 1
+		if prefix := strings.TrimSpace(strings.TrimSuffix(intervalVar, "M")); prefix != "" {
+			n, err := strconv.Atoi(prefix)
+			if err != nil || n < 1 {
+				return "", fmt.Errorf("error parsing interval %v", intervalVar)
+			}
+			months = n
+		}
+
+		if months == 1 {
+			// Bucket to the first day of each calendar month.
+			return fmt.Sprintf("TIMESTAMP((PARSE_DATE(\"%%Y-%%m-%%d\",CONCAT( CAST((EXTRACT(YEAR FROM %s)) AS STRING),'-',CAST((EXTRACT(MONTH FROM %s)) AS STRING),'-','01'))))", timeVar, timeVar), nil
+		}
+
+		// Bucket into N-month windows aligned to the start of the calendar year
+		// (e.g. 3M -> Jan/Apr/Jul/Oct).
+		return fmt.Sprintf("TIMESTAMP(DATE(EXTRACT(YEAR FROM %s), CAST(FLOOR((EXTRACT(MONTH FROM %s) - 1) / %d) * %d + 1 AS INT64), 1))", timeVar, timeVar, months, months), nil
 	}
 
 	interval, err := gtime.ParseInterval(intervalVar)

--- a/pkg/bigquery/macros_test.go
+++ b/pkg/bigquery/macros_test.go
@@ -56,6 +56,30 @@ func Test_macros(t *testing.T) {
 			"TIMESTAMP((PARSE_DATE(\"%Y-%m-%d\",CONCAT( CAST((EXTRACT(YEAR FROM created_at)) AS STRING),'-',CAST((EXTRACT(MONTH FROM created_at)) AS STRING),'-','01'))))",
 			nil,
 		},
+		{
+			"time groups 3M (quarterly)",
+			"timeGroup",
+			&sqlutil.Query{},
+			[]string{"created_at", "3M"},
+			"TIMESTAMP(DATE(EXTRACT(YEAR FROM created_at), CAST(FLOOR((EXTRACT(MONTH FROM created_at) - 1) / 3) * 3 + 1 AS INT64), 1))",
+			nil,
+		},
+		{
+			"time groups 6M",
+			"timeGroup",
+			&sqlutil.Query{},
+			[]string{"created_at", "6M"},
+			"TIMESTAMP(DATE(EXTRACT(YEAR FROM created_at), CAST(FLOOR((EXTRACT(MONTH FROM created_at) - 1) / 6) * 6 + 1 AS INT64), 1))",
+			nil,
+		},
+		{
+			"time groups 12M (yearly)",
+			"timeGroup",
+			&sqlutil.Query{},
+			[]string{"created_at", "12M"},
+			"TIMESTAMP(DATE(EXTRACT(YEAR FROM created_at), CAST(FLOOR((EXTRACT(MONTH FROM created_at) - 1) / 12) * 12 + 1 AS INT64), 1))",
+			nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
@@ -65,6 +89,19 @@ func Test_macros(t *testing.T) {
 			}
 			if res != tt.expected {
 				t.Errorf("unexpected result %v, expecting %v", res, tt.expected)
+			}
+		})
+	}
+}
+
+// An interval that is empty after stripping quotes (e.g. "''") must return an
+// error rather than panicking with a slice-bounds-out-of-range.
+func Test_macroTimeGroup_emptyIntervalReturnsError(t *testing.T) {
+	for _, interval := range []string{"", "''", "\"\""} {
+		t.Run("interval="+interval, func(t *testing.T) {
+			res, err := macros["timeGroup"](&sqlutil.Query{}, []string{"created_at", interval})
+			if err == nil {
+				t.Errorf("expected an error for empty interval %q, got result %q", interval, res)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Fixes two bugs in the `$__timeGroup` macro (`pkg/bigquery/macros.go`):

1. **Month multiplier ignored (#500)** — for month intervals the numeric multiplier was never parsed, so `3M`, `6M`, `12M` all generated the same SQL as `1M` (monthly buckets), silently producing wrong aggregations with no error. The macro now parses the multiplier and emits N-month buckets aligned to the calendar year (e.g. `3M` → Jan/Apr/Jul/Oct).
2. **Panic on empty interval (#501)** — a quote-only interval like `''` passed the empty-argument guard and then `intervalVar[len(intervalVar)-1:]` panicked with `slice bounds out of range [-1:]`. It now returns a clear "interval cannot be empty" error.

The single-month (`1M`) path is unchanged (identical generated SQL), so existing dashboards are unaffected.

## Verification

Added unit tests for `3M` / `6M` / `12M` and the empty/quote-only interval, and verified against real BigQuery:

- `$__timeGroup(ts, 3M)` buckets Feb/May/Aug/Nov 2024 → `2024-01-01` / `04-01` / `07-01` / `10-01`
- `$__timeGroup(ts, 12M)` buckets any 2024 month → `2024-01-01`
- `$__timeGroup(ts, '')` → returns `the second parameter(interval) for $__timeGroup macro cannot be empty` (no panic)

`go test ./pkg/...` passes.

Fixes #500
Fixes #501
