### PR TITLE
fix: guard LIMIT emission against NaN/null/empty from cleared input

### DIFF
--- a/.changeset/limit-null-roundtrip.md
+++ b/.changeset/limit-null-roundtrip.md
@@ -1,0 +1,5 @@
+---
+'grafana-bigquery-datasource': patch
+---
+
+Fix: clearing the `Limit` input in the visual query builder no longer produces invalid `LIMIT null` SQL after dashboard save/reload. `toRawSql` now only emits a `LIMIT` clause for finite non-negative numbers, and the input setter stores `undefined` (rather than `NaN`) for an empty value.

--- a/src/components/visual-query-builder/SQLOrderByRow.tsx
+++ b/src/components/visual-query-builder/SQLOrderByRow.tsx
@@ -31,7 +31,11 @@ export function SQLOrderByRow({ sql, onSqlChange, columns, showOffset }: SQLOrde
 
   const onLimitChange = useCallback(
     (event: React.FormEvent<HTMLInputElement>) => {
-      const newSql: SQLExpression = { ...sql, limit: Number.parseInt(event.currentTarget.value, 10) };
+      const raw = event.currentTarget.value;
+      // Empty input -> undefined, not NaN: NaN survives in-memory but JSON.stringify
+      // normalizes it to null, which would then bypass the LIMIT guard on reload.
+      const limit = raw === '' ? undefined : Number.parseInt(raw, 10);
+      const newSql: SQLExpression = { ...sql, limit };
       onSqlChange(newSql);
     },
     [onSqlChange, sql]

--- a/src/utils/sql.utils.test.ts
+++ b/src/utils/sql.utils.test.ts
@@ -146,6 +146,30 @@ describe('toRawSql function', () => {
     const result = toRawSql({ ...queryWithDefaults, sql });
     expect(result).toEqual(`SELECT name ${from} `);
   });
+
+  it(`should not set limit when it is NaN (e.g. user just cleared the input)`, () => {
+    const sql: SQLExpression = { columns: [columns[1]], limit: Number.NaN };
+    const result = toRawSql({ ...queryWithDefaults, sql });
+    expect(result).toEqual(`SELECT name ${from} `);
+  });
+
+  it(`should not set limit when it is null (e.g. NaN normalized to null by JSON round-trip)`, () => {
+    const sql: SQLExpression = { columns: [columns[1]], limit: null as any };
+    const result = toRawSql({ ...queryWithDefaults, sql });
+    expect(result).toEqual(`SELECT name ${from} `);
+  });
+
+  it(`should not set limit when it is an empty string`, () => {
+    const sql: SQLExpression = { columns: [columns[1]], limit: '' as any };
+    const result = toRawSql({ ...queryWithDefaults, sql });
+    expect(result).toEqual(`SELECT name ${from} `);
+  });
+
+  it(`should not set limit when it is Infinity`, () => {
+    const sql: SQLExpression = { columns: [columns[1]], limit: Number.POSITIVE_INFINITY };
+    const result = toRawSql({ ...queryWithDefaults, sql });
+    expect(result).toEqual(`SELECT name ${from} `);
+  });
 });
 
 describe('haveColumns', () => {

--- a/src/utils/sql.utils.ts
+++ b/src/utils/sql.utils.ts
@@ -39,8 +39,10 @@ export function toRawSql({ sql, dataset, table, project }: BigQueryQueryNG): str
     rawQuery += `${sql.orderByDirection} `;
   }
 
-  // Although LIMIT 0 doesn't make sense, it is still possible to have LIMIT 0
-  if (sql.limit !== undefined && sql.limit >= 0) {
+  // Although LIMIT 0 doesn't make sense, it is still possible to have LIMIT 0.
+  // Use isFinite so that NaN/null/"" — which can appear after JSON round-trip of
+  // a cleared input — don't slip through as "LIMIT null"/"LIMIT ".
+  if (typeof sql.limit === 'number' && Number.isFinite(sql.limit) && sql.limit >= 0) {
     rawQuery += `LIMIT ${sql.limit} `;
   }
   return rawQuery;


### PR DESCRIPTION
Fixes #514.

### Summary

In Builder mode, clearing the Limit input stored `Number.parseInt('', 10) === NaN` in `sql.limit`. `JSON.stringify(NaN)` is `"null"`, so any persistence path (Explore URL `left=` param, dashboard panel JSON) normalized the value to `null` on reload. `toRawSql`'s guard `sql.limit !== undefined && sql.limit >= 0` then accepted `null` (which coerces to `0` in `>=`) and emitted the literal string `LIMIT null` — invalid SQL that BigQuery rejects with a syntax error.

### Change

Two small fixes, defense-in-depth at both the data-model and the emitter:

- `src/components/visual-query-builder/SQLOrderByRow.tsx` — store `undefined` for an empty input rather than `NaN`, so the cleared state survives a JSON round-trip cleanly.
- `src/utils/sql.utils.ts` — tighten the LIMIT guard to `typeof sql.limit === 'number' && Number.isFinite(sql.limit) && sql.limit >= 0`. `null`, `NaN`, `""`, and `Infinity` are all rejected before interpolation.

### Tests

Added regression cases to `src/utils/sql.utils.test.ts` covering `NaN`, `null`, `""`, and `Infinity` for `sql.limit`. All existing cases (`50`, `0`, `-2`) still pass.