### PR TITLE
chore: make grafanaDependency prerelease-inclusive

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -9,7 +9,7 @@
   "backend": true,
   "executable": "gpx_bigquery",
   "dependencies": {
-    "grafanaDependency": ">=11.6.0"
+    "grafanaDependency": ">=11.6.0-0"
   },
   "queryOptions": {
     "maxDataPoints": true


### PR DESCRIPTION
grafana-com PR #17309 made the plugins publish API reject Grafana-owned plugins whose `grafanaDependency` lower bound isn't prerelease-inclusive, so the next publish of this plugin would fail.

This updates the range from `>=11.6.0` to `>=11.6.0-0` so prerelease Grafana builds are matched and publishing keeps working. No behavior change for released Grafana versions.

Ref: https://github.com/grafana/grafana-com/pull/17309