### PR TITLE
Feature: GCE Alerting

### DIFF
--- a/.changeset/beige-signs-rhyme.md
+++ b/.changeset/beige-signs-rhyme.md
@@ -1,0 +1,52 @@
+---
+'grafana-bigquery-datasource': minor
+---
+
+# Add a "Use GCE for alerting" option to authenticate alert queries with GCE
+
+## Problem
+
+When the data source is configured with **Forward OAuth Identity**, queries
+authenticate by forwarding the signed-in user's OAuth token to BigQuery. Alert
+rules evaluate in the background with no user session, so there is no token to
+forward and the query reaches BigQuery with no credentials:
+
+```text
+googleapi: Error 401: Request is missing required authentication credential.
+Expected OAuth 2 access token... reason: CREDENTIALS_MISSING
+```
+
+This makes alerting unusable on instances that rely on OAuth identity forwarding.
+
+## Solution
+
+A new, opt-in data source setting, **Use GCE for alerting**. When enabled, queries
+that originate from Grafana alerting authenticate with the **GCE service account**
+(Application Default Credentials) instead of the absent forwarded identity.
+Interactive queries are unchanged and continue to forward the user's identity.
+
+## How it works
+
+- **Alert detection** — Grafana sets the `FromAlert` marker as request metadata
+  (`QueryDataRequest.Headers`), not as a forwarded HTTP header, so it isn't visible
+  in `Connect`. It is read in `MutateQueryData` (sqlds's `QueryDataMutator` hook,
+  which receives the full request) and propagated via `context`.
+- **Auth switch** — In `Connect`, when the request is from alerting *and* the option
+  is enabled *and* OAuth passthrough is the configured auth, the HTTP client is built
+  with the existing GCE token-provider path instead of header forwarding. Existing
+  impersonation settings are preserved.
+- **Connection caching** — GCE-authenticated alert connections are cached under a
+  separate key (`…:gce-alerting`) so they are never reused for interactive OAuth
+  queries, and vice versa.
+
+## Backward compatibility
+
+Fully backward compatible. The option defaults to off; existing data sources behave
+exactly as before until a user explicitly enables it.
+
+## Notes
+
+- GCE auth resolves via `google.DefaultTokenSource`, so the environment must provide
+  credentials (GKE Workload Identity, or `GOOGLE_APPLICATION_CREDENTIALS`).
+- The override covers the standard query path; the Storage Read API client still uses
+  the JWT token source.

--- a/pkg/bigquery/datasource.go
+++ b/pkg/bigquery/datasource.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 
 	bq "cloud.google.com/go/bigquery"
@@ -81,6 +82,42 @@ func newBigQueryDatasource() *BigQueryDatasource {
 	}
 }
 
+type fromAlertContextKey struct{}
+
+// MutateQueryData runs before sqlds handles the queries (sqlds.QueryDataMutator). It
+// inspects the request for Grafana's alerting marker and records the result in the
+// context, because by the time sqlds calls Connect only the forwarded HTTP headers are
+// available and the "FromAlert" marker is request metadata rather than an HTTP header.
+func (s *BigQueryDatasource) MutateQueryData(ctx context.Context, req *backend.QueryDataRequest) (context.Context, *backend.QueryDataRequest) {
+	if requestIsFromAlert(req) {
+		ctx = context.WithValue(ctx, fromAlertContextKey{}, true)
+	}
+	return ctx, req
+}
+
+// requestIsFromAlert reports whether a query request originated from Grafana alerting.
+// Grafana sets the "FromAlert" marker, which depending on the version arrives either as
+// request metadata (req.Headers) or as a forwarded HTTP header.
+func requestIsFromAlert(req *backend.QueryDataRequest) bool {
+	if req == nil {
+		return false
+	}
+	if strings.EqualFold(req.GetHTTPHeader("FromAlert"), "true") {
+		return true
+	}
+	for name, value := range req.Headers {
+		if strings.EqualFold(name, "FromAlert") && strings.EqualFold(value, "true") {
+			return true
+		}
+	}
+	return false
+}
+
+func fromAlertFromContext(ctx context.Context) bool {
+	fromAlert, _ := ctx.Value(fromAlertContextKey{}).(bool)
+	return fromAlert
+}
+
 func (s *BigQueryDatasource) Connect(ctx context.Context, config backend.DataSourceInstanceSettings, queryArgs json.RawMessage) (*sql.DB, error) {
 	loggerWithContext := s.logger.FromContext(ctx)
 	settings, err := loadSettings(&config)
@@ -95,9 +132,21 @@ func (s *BigQueryDatasource) Connect(ctx context.Context, config backend.DataSou
 
 	isQueryArgsSet := args != nil
 
-	connectionSettings := getConnectionSettings(settings, args, isQueryArgsSet)
+	// When the data source forwards the user's OAuth identity, alert queries have no
+	// user token to forward. If "Use GCE for alerting" is enabled, authenticate those
+	// alert queries with the GCE service account instead of the forwarded identity.
+	useGceForAlerting := settings.OAuthPassthroughEnabled && settings.UseGceForAlerting &&
+		(fromAlertFromContext(ctx) || isFromAlert(args.Headers))
+	effectiveSettings := settings
+	if useGceForAlerting {
+		loggerWithContext.Debug("Alert query detected; using GCE authentication instead of forwarded OAuth identity")
+		effectiveSettings.AuthenticationType = "gce"
+		effectiveSettings.OAuthPassthroughEnabled = false
+	}
 
-	if settings.AuthenticationType == "gce" && connectionSettings.Project == "" {
+	connectionSettings := getConnectionSettings(effectiveSettings, args, isQueryArgsSet)
+
+	if effectiveSettings.AuthenticationType == "gce" && connectionSettings.Project == "" {
 		defaultProject, err := utils.GCEDefaultProject(context.Background(), BigQueryScope)
 		if err != nil {
 			return nil, errors.WithMessage(err, "Failed to retrieve default GCE project")
@@ -106,6 +155,11 @@ func (s *BigQueryDatasource) Connect(ctx context.Context, config backend.DataSou
 	}
 
 	connectionKey := fmt.Sprintf("%s/%s:%s:%t", config.UID, connectionSettings.Location, connectionSettings.Project, connectionSettings.EnableStorageAPI)
+	// Cache GCE-authenticated alert connections separately so they are never reused for
+	// interactive queries that forward the OAuth identity (and vice versa).
+	if useGceForAlerting {
+		connectionKey += ":gce-alerting"
+	}
 
 	if s.getResourceManagerService(config.UID) == nil {
 		err := s.createResourceManagerService(ctx, config, settings, config.UID)
@@ -143,7 +197,7 @@ func (s *BigQueryDatasource) Connect(ctx context.Context, config backend.DataSou
 		s.connections.Store(connectionKey, conn{db: db, driver: dr})
 		return db, nil
 	} else {
-		client, err := newHTTPClient(settings, opts, bigQueryRoute)
+		client, err := newHTTPClient(effectiveSettings, opts, bigQueryRoute)
 		if err != nil {
 			loggerWithContext.Warn("Failed to get http client options", "error", err)
 			return nil, err
@@ -463,6 +517,23 @@ func (s *BigQueryDatasource) getApi(ctx context.Context, project, location strin
 func getDatasourceSettings(ctx context.Context) *backend.DataSourceInstanceSettings {
 	plugin := PluginConfigFromContext(ctx)
 	return plugin.DataSourceInstanceSettings
+}
+
+// isFromAlert reports whether the query originated from Grafana alerting. Grafana
+// sets the "FromAlert" HTTP header on alert-rule evaluations, which is forwarded to
+// the plugin and surfaced here via the connection args (grafana-http-headers).
+func isFromAlert(headers map[string][]string) bool {
+	for name, values := range headers {
+		if !strings.EqualFold(name, "FromAlert") {
+			continue
+		}
+		for _, v := range values {
+			if strings.EqualFold(v, "true") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func parseConnectionArgs(queryArgs json.RawMessage) (*ConnectionArgs, error) {

--- a/pkg/bigquery/datasource_test.go
+++ b/pkg/bigquery/datasource_test.go
@@ -156,6 +156,100 @@ func Test_datasourceConnection(t *testing.T) {
 	})
 }
 
+func Test_isFromAlert(t *testing.T) {
+	assert.True(t, isFromAlert(map[string][]string{"FromAlert": {"true"}}))
+	// header keys arrive canonicalized via http.Header, match case-insensitively
+	assert.True(t, isFromAlert(map[string][]string{"Fromalert": {"True"}}))
+	assert.False(t, isFromAlert(map[string][]string{"FromAlert": {"false"}}))
+	assert.False(t, isFromAlert(map[string][]string{"Authorization": {"Bearer x"}}))
+	assert.False(t, isFromAlert(nil))
+}
+
+func Test_requestIsFromAlert(t *testing.T) {
+	assert.False(t, requestIsFromAlert(nil))
+	assert.False(t, requestIsFromAlert(&backend.QueryDataRequest{}))
+	// Grafana sets "FromAlert" as request metadata (not an http_-prefixed header).
+	assert.True(t, requestIsFromAlert(&backend.QueryDataRequest{Headers: map[string]string{"FromAlert": "true"}}))
+	assert.True(t, requestIsFromAlert(&backend.QueryDataRequest{Headers: map[string]string{"fromalert": "TRUE"}}))
+	assert.False(t, requestIsFromAlert(&backend.QueryDataRequest{Headers: map[string]string{"FromAlert": "false"}}))
+}
+
+func Test_MutateQueryData_propagatesAlertFlag(t *testing.T) {
+	ds := newBigQueryDatasource()
+
+	ctx, _ := ds.MutateQueryData(context.Background(), &backend.QueryDataRequest{Headers: map[string]string{"FromAlert": "true"}})
+	assert.True(t, fromAlertFromContext(ctx))
+
+	ctx, _ = ds.MutateQueryData(context.Background(), &backend.QueryDataRequest{})
+	assert.False(t, fromAlertFromContext(ctx))
+}
+
+func Test_useGceForAlerting(t *testing.T) {
+	newDS := func() *BigQueryDatasource {
+		return &BigQueryDatasource{
+			bqFactory: func(ctx context.Context, projectID string, opts ...option.ClientOption) (*bq.Client, error) {
+				return &bq.Client{Location: "test"}, nil
+			},
+			resourceManagerServices: make(map[string]*cloudresourcemanager.Service),
+			logger:                  backend.NewLoggerWith("bigquery datasource"),
+		}
+	}
+
+	// Data source forwards OAuth identity and has "Use GCE for alerting" enabled.
+	settings := backend.DataSourceInstanceSettings{
+		ID:       1,
+		UID:      "uid-1",
+		JSONData: []byte(`{"authenticationType":"forwardOAuthIdentity","oauthPassThru":true,"useGceForAlerting":true,"defaultProject":"raintank-dev"}`),
+	}
+
+	t.Run("alert query uses a dedicated GCE connection", func(t *testing.T) {
+		ds := newDS()
+		_, err := ds.Connect(context.Background(), settings, []byte(`{"grafana-http-headers":{"FromAlert":["true"]}}`))
+		assert.Nil(t, err)
+
+		_, gceConn := ds.connections.Load("uid-1/:raintank-dev:false:gce-alerting")
+		assert.True(t, gceConn, "alert query should create a :gce-alerting connection")
+		_, passthroughConn := ds.connections.Load("uid-1/:raintank-dev:false")
+		assert.False(t, passthroughConn, "alert query should not reuse the passthrough connection")
+	})
+
+	t.Run("alert flag from context routes to GCE even without forwarded headers", func(t *testing.T) {
+		ds := newDS()
+		// Simulate the sqlds flow: MutateQueryData stamps the alert flag onto the
+		// context, then Connect is called with no grafana-http-headers.
+		ctx, _ := ds.MutateQueryData(context.Background(), &backend.QueryDataRequest{Headers: map[string]string{"FromAlert": "true"}})
+		_, err := ds.Connect(ctx, settings, []byte(`{}`))
+		assert.Nil(t, err)
+
+		_, gceConn := ds.connections.Load("uid-1/:raintank-dev:false:gce-alerting")
+		assert.True(t, gceConn, "context alert flag should create a :gce-alerting connection")
+	})
+
+	t.Run("interactive query keeps the OAuth passthrough connection", func(t *testing.T) {
+		ds := newDS()
+		_, err := ds.Connect(context.Background(), settings, []byte(`{}`))
+		assert.Nil(t, err)
+
+		_, passthroughConn := ds.connections.Load("uid-1/:raintank-dev:false")
+		assert.True(t, passthroughConn, "interactive query should use the passthrough connection")
+		_, gceConn := ds.connections.Load("uid-1/:raintank-dev:false:gce-alerting")
+		assert.False(t, gceConn, "interactive query should not use the GCE alert connection")
+	})
+
+	t.Run("alert query is unaffected when the option is disabled", func(t *testing.T) {
+		ds := newDS()
+		disabled := settings
+		disabled.JSONData = []byte(`{"authenticationType":"forwardOAuthIdentity","oauthPassThru":true,"useGceForAlerting":false,"defaultProject":"raintank-dev"}`)
+		_, err := ds.Connect(context.Background(), disabled, []byte(`{"grafana-http-headers":{"FromAlert":["true"]}}`))
+		assert.Nil(t, err)
+
+		_, passthroughConn := ds.connections.Load("uid-1/:raintank-dev:false")
+		assert.True(t, passthroughConn, "with the option off, alert queries should use the passthrough connection")
+		_, gceConn := ds.connections.Load("uid-1/:raintank-dev:false:gce-alerting")
+		assert.False(t, gceConn)
+	})
+}
+
 func Test_Projects_doesNotPanicWhenResourceManagerServiceMissing(t *testing.T) {
 	origPluginConfigFromContext := PluginConfigFromContext
 	defer func() { PluginConfigFromContext = origPluginConfigFromContext }()

--- a/pkg/bigquery/types/types.go
+++ b/pkg/bigquery/types/types.go
@@ -22,6 +22,7 @@ type BigQuerySettings struct {
 	UsingImpersonation          bool   `json:"usingImpersonation"`
 	ServiceAccountToImpersonate string `json:"serviceAccountToImpersonate"`
 	OAuthPassthroughEnabled     bool   `json:"oauthPassThru"`
+	UseGceForAlerting           bool   `json:"useGceForAlerting"`
 
 	// Workload Identity Federation fields (read by Grafana Cloud's auth middleware)
 	WorkloadIdentityPoolProvider string `json:"workloadIdentityPoolProvider"`

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -8,12 +8,12 @@ import {
 import { AuthConfig, GoogleAuthType } from '@grafana/google-sdk';
 import { ConfigSection, DataSourceDescription } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
-import { Combobox, Field, Input, SecureSocksProxySettings } from '@grafana/ui';
+import { Checkbox, Combobox, Field, Input, SecureSocksProxySettings } from '@grafana/ui';
 
 import { PROCESSING_LOCATIONS } from '../constants';
 import { BigQueryOptions, BigQuerySecureJsonData, bigQueryAuthTypes } from '../types';
 
-import { ConfigurationHelp } from './/ConfigurationHelp';
+import { ConfigurationHelp } from './ConfigurationHelp';
 import { Divider } from './Divider';
 
 export type BigQueryConfigEditorProps = DataSourcePluginOptionsEditorProps<BigQueryOptions, BigQuerySecureJsonData>;
@@ -28,6 +28,16 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
       jsonData: {
         ...jsonData,
         MaxBytesBilled: Number(event.target.value),
+      },
+    });
+  };
+
+  const onUseGceForAlertingChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...jsonData,
+        useGceForAlerting: event.currentTarget.checked,
       },
     });
   };
@@ -129,6 +139,12 @@ export const BigQueryConfigEditor: React.FC<BigQueryConfigEditorProps> = (props)
             type={'number'}
             value={jsonData.MaxBytesBilled || ''}
             onChange={onMaxBytesBilledChange}
+          />
+        </Field>
+        <Field label="Use GCE for alerting" description="Use the GCE service account for alerting queries.">
+          <Checkbox
+            value={jsonData.useGceForAlerting || false}
+            onChange={onUseGceForAlertingChange}
           />
         </Field>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface BigQueryOptions extends DataSourceOptions {
   MaxBytesBilled?: number;
   serviceEndpoint?: string;
   oauthPassThru?: boolean;
+  useGceForAlerting?: boolean;
 }
 
 export const bigQueryAuthTypes = [


### PR DESCRIPTION
# Add a "Use GCE for alerting" option to authenticate alert queries with GCE

## Problem

When the data source is configured with **Forward OAuth Identity**, queries
authenticate by forwarding the signed-in user's OAuth token to BigQuery. Alert
rules evaluate in the background with no user session, so there is no token to
forward and the query reaches BigQuery with no credentials:

```text
googleapi: Error 401: Request is missing required authentication credential.
Expected OAuth 2 access token... reason: CREDENTIALS_MISSING
```

This makes alerting unusable on instances that rely on OAuth identity forwarding.

## Solution

A new, opt-in data source setting, **Use GCE for alerting**. When enabled, queries
that originate from Grafana alerting authenticate with the **GCE service account**
(Application Default Credentials) instead of the absent forwarded identity.
Interactive queries are unchanged and continue to forward the user's identity.

## How it works

- **Alert detection** — Grafana sets the `FromAlert` marker as request metadata
  (`QueryDataRequest.Headers`), not as a forwarded HTTP header, so it isn't visible
  in `Connect`. It is read in `MutateQueryData` (sqlds's `QueryDataMutator` hook,
  which receives the full request) and propagated via `context`.
- **Auth switch** — In `Connect`, when the request is from alerting *and* the option
  is enabled *and* OAuth passthrough is the configured auth, the HTTP client is built
  with the existing GCE token-provider path instead of header forwarding. Existing
  impersonation settings are preserved.
- **Connection caching** — GCE-authenticated alert connections are cached under a
  separate key (`…:gce-alerting`) so they are never reused for interactive OAuth
  queries, and vice versa.

## Backward compatibility

Fully backward compatible. The option defaults to off; existing data sources behave
exactly as before until a user explicitly enables it.

## Notes

- GCE auth resolves via `google.DefaultTokenSource`, so the environment must provide
  credentials (GKE Workload Identity, or `GOOGLE_APPLICATION_CREDENTIALS`).
- The override covers the standard query path; the Storage Read API client still uses
  the JWT token source.