### PR TITLE
ci: use shared reusable add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,4 +1,4 @@
-name: Add issues to Data Sources team project
+name: Add issues & PRs to Grafana Data Source Plugins Squad project
 on:
   issues:
     types:
@@ -7,22 +7,9 @@ on:
     types:
       - opened
 
-permissions: {}
-
 jobs:
   add-to-project:
-    name: Add issue to project
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
-    steps:
-      - id: get-github-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
-        with:
-          github_app: grafana-oss-big-tent
-      - name: Add to project
-        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
-        with:
-          project-url: https://github.com/orgs/grafana/projects/1085
-          github-token: ${{ steps.get-github-token.outputs.token }}
+    uses: grafana/data-sources-ci-workflows/.github/workflows/reusable-add-to-project.yml@main # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
Migrates the add-to-project workflow to the shared reusable workflow from `grafana/data-sources-ci-workflows`.