### PR TITLE
chore: remove dead time-shift and findTimeField helpers

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,6 @@ export interface BigQueryQueryNG extends DataQuery {
   convertToUTC?: boolean;
   sharded?: boolean;
   queryPriority?: QueryPriority;
-  timeShift?: string;
   editorMode?: EditorMode;
   sql?: SQLExpression;
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -5,19 +5,14 @@ import {
   convertToUtc,
   escapeLiteral,
   extractFromClause,
-  findTimeField,
   formatBigqueryError,
   formatDateToString,
   getDatasourceId,
   getInterval,
-  getShiftPeriod,
-  getTimeShift,
-  getUnixSecondsFromString,
   handleError,
   isQueryValid,
   quoteFiledName,
   quoteLiteral,
-  replaceTimeShift,
   setDatasourceId,
 } from 'utils';
 
@@ -33,28 +28,11 @@ describe('Utils', () => {
     expect(res).toBe('just like that: status text');
   });
 
-  test('getShiftPeriod', () => {
-    const interval = '55 min';
-
-    const res = getShiftPeriod(interval);
-    expect(res).toEqual(['m', '55']);
-  });
-
   test('extractFromClause', () => {
     const sql = 'select a from `prj.ds.dt` where';
 
     const res = extractFromClause(sql);
     expect(res).toEqual(['prj', 'ds', 'dt']);
-  });
-
-  test('findTimeField', () => {
-    const sql = 'select tm,b from `prj.ds.dt` where';
-    const fl = {
-      text: 'tm',
-    };
-    const timeFields = new Array(fl);
-    const res = findTimeField(sql, timeFields);
-    expect(res.text).toBe('tm');
   });
 
   test('applyQueryDefaults should handle location change from auto to US', () => {
@@ -140,20 +118,6 @@ describe('Utils', () => {
     const res = getInterval(q, true);
     expect(res[0]).toBe('1m');
     expect(res[1]).toBe('10');
-  });
-
-  test('getTimeShift and replaceTimeShift behave as expected', () => {
-    const sql = 'select $__timeShifting(55 min) as shifted';
-    expect(getTimeShift(sql)).toBe('55 min');
-    const replaced = replaceTimeShift(sql);
-    expect(replaced).not.toContain('$__timeShifting(');
-  });
-
-  test('getUnixSecondsFromString handles different periods', () => {
-    expect(getUnixSecondsFromString('5s')).toBe(5);
-    expect(getUnixSecondsFromString('2 min')).toBe(120);
-    expect(getUnixSecondsFromString('1h')).toBe(3600);
-    expect(getUnixSecondsFromString(undefined)).toBe(0);
   });
 
   test('convertToUtc applies timezone offset', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-import { DataQueryRequest, DurationUnit, dateTime } from '@grafana/data';
+import { DataQueryRequest } from '@grafana/data';
 import { EditorMode } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 import { BigQueryAPI } from 'api';
@@ -23,8 +23,6 @@ import { BigQueryDatasource } from 'datasource';
 import SqlParser from 'sql_parser';
 import { BigQueryQueryNG, QueryFormat } from 'types';
 import { createFunctionField, setGroupByField } from 'utils/sql.utils';
-
-export const SHIFTED = '_shifted';
 
 export function formatBigqueryError(error: any) {
   let message = 'BigQuery: ';
@@ -44,48 +42,10 @@ export function formatBigqueryError(error: any) {
   };
 }
 
-export function getShiftPeriod(strInterval: string): [DurationUnit, string] {
-  const shift = strInterval.match(/\d+/)![0];
-  strInterval = strInterval.substring(shift.length, strInterval.length);
-
-  if (strInterval.trim() === 'min') {
-    strInterval = 'm';
-  }
-  return [strInterval as DurationUnit, shift];
-}
-
 export function extractFromClause(sql: string) {
   return SqlParser.getProjectDatasetTableFromSql(sql);
 }
 
-// TODO: fix any annotation
-export function findTimeField(sql: string, timeFields: any[]) {
-  const select = sql.search(/select/i);
-  const from = sql.search(/from/i);
-  const fields = sql.substring(select + 6, from);
-  const splitFrom = fields.split(',');
-  let col;
-  for (let i = 0; i < splitFrom.length; i++) {
-    let field = splitFrom[i].search(/ AS /i);
-    if (field === -1) {
-      field = splitFrom[i].length;
-    }
-    col = splitFrom[i].substring(0, field).trim().replace('`', '').replace('`', '');
-    col = col.replace(/\$__timeGroupAlias\(/g, '');
-    col = col.replace(/\$__timeGroup\(/g, '');
-    col = col.replace(/\$__timeFilter\(/g, '');
-    col = col.replace(/\$__timeFrom\(/g, '');
-    col = col.replace(/\$__timeTo\(/g, '');
-    col = col.replace(/\$__millisTimeTo\(/g, '');
-    col = col.replace(/\$__millisTimeFrom\(/g, '');
-    for (const fl of timeFields) {
-      if (fl.text === col) {
-        return fl;
-      }
-    }
-  }
-  return null;
-}
 export function handleError(error: any) {
   if (error.cancelled === true) {
     return [];
@@ -95,54 +55,6 @@ export function handleError(error: any) {
     msg = error.data.error;
   }
   throw formatBigqueryError(msg);
-}
-
-export function createTimeShiftQuery(query: BigQueryQueryNG) {
-  const res = getTimeShift(query.rawSql);
-
-  if (!res) {
-    return null;
-  }
-
-  const copy = { ...query };
-
-  console.log('createTimeShiftQuery', query);
-  copy.rawSql = replaceTimeShift(copy.rawSql);
-  copy.timeShift = res;
-  copy.refId += SHIFTED + '_' + res;
-  return copy;
-}
-
-export function setupTimeShiftQuery(query: BigQueryQueryNG, options: DataQueryRequest<BigQueryQueryNG>) {
-  if (!query.timeShift) {
-    return { ...options };
-  }
-
-  const copy = { ...options };
-
-  let strInterval = query.timeShift;
-  const res = getShiftPeriod(strInterval);
-  strInterval = res[0];
-
-  if (!['s', 'min', 'h', 'd', 'w', 'm', 'w', 'y', 'M'].includes(strInterval)) {
-    return copy;
-  }
-
-  strInterval = res[0];
-
-  const shift = res[1];
-
-  if (strInterval === 'min') {
-    strInterval = 'm';
-  }
-
-  copy.range = {
-    from: dateTime(options.range.from).subtract(shift, strInterval as DurationUnit),
-    to: dateTime(options.range.to).subtract(shift, strInterval as DurationUnit),
-    raw: { ...options.range.raw }, // huh, not relevant really
-  };
-
-  return copy;
 }
 
 export function updatePartition(q: string, options: DataQueryRequest<BigQueryQueryNG>) {
@@ -226,47 +138,6 @@ export function getInterval(q: string, alias: boolean) {
     interval[1] = res[0].split(',')[2] ? res[0].split(',')[2].trim() : res[0].split(',')[2];
   }
   return interval;
-}
-
-export function getUnixSecondsFromString(str?: string) {
-  if (str === undefined) {
-    return 0;
-  }
-  const res = getShiftPeriod(str);
-  const groupPeriod = res[0];
-  const groupVal = parseInt(res[1], 10);
-
-  switch (groupPeriod) {
-    case 's':
-      return 1 * groupVal;
-    case 'm':
-      return 60 * groupVal;
-    case 'h':
-      return 3600 * groupVal;
-    case 'd':
-      return groupVal * 86400;
-    case 'w':
-      return 604800 * groupVal;
-    case 'M':
-      return 2629743 * groupVal;
-    case 'y':
-      return 31536000 * groupVal;
-  }
-  return 0;
-}
-
-export function getTimeShift(q: string) {
-  let res = q.match(/(.*\$__timeShifting\().*?(?=\))/g);
-  let result = null;
-
-  if (res) {
-    result = res[0].substring(1 + res[0].lastIndexOf('('));
-  }
-  return result;
-}
-
-export function replaceTimeShift(q: string) {
-  return q.replace(/(\$__timeShifting\().*?(?=\))./g, '');
 }
 
 export function convertToUtc(d: Date) {


### PR DESCRIPTION
## What

Removes the orphaned per-query time-shift feature and its supporting helpers from `src/utils.ts`, plus their tests and the now-unused `timeShift` field on `BigQueryQueryNG`:

- `$__timeShifting(...)` machinery: `createTimeShiftQuery`, `setupTimeShiftQuery`, `getTimeShift`, `replaceTimeShift`, `getShiftPeriod`, `getUnixSecondsFromString`, and the `SHIFTED` constant
- `findTimeField`, which contained the only references to `$__millisTimeFrom`/`$__millisTimeTo`, macros that have never had a backend implementation in this plugin

## Why

None of these functions has a caller anywhere in the plugin. They are remnants of the DoiT-era plugin's per-query time-shift feature (`Support time shift per query`) that survived the repo migration as dead exports, complete with a leftover `console.log` in `createTimeShiftQuery`. Because nothing invokes the machinery, `$__timeShifting(...)` in a query does nothing today: it passes through to BigQuery unexpanded and fails as a syntax error, so no query can be depending on it. The removal is behaviour-neutral by construction.

Surfaced during the macro survey behind #550. Users who want time shifting have Grafana's panel-level relative time option, which is the supported path.

## User-facing impact

None. The removed macros were non-functional, and the `timeShift` query-model field was only written by the dead code (a stray `timeShift` property in a saved dashboard JSON is simply ignored, as it already was).

Noted while here, deliberately out of scope: several other DoiT-era exports in `src/utils.ts` (`formatBigqueryError`, `handleError`, `extractFromClause`, `updatePartition`, `updateTableSuffix`, `getInterval`, `convertToUtc`) also have no callers outside their own tests and could go in a follow-up.