### PR TITLE
Fixed version requirement

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -9,7 +9,7 @@
   "backend": true,
   "executable": "gpx_bigquery",
   "dependencies": {
-    "grafanaDependency": ">=11.6.11 <12 || >=12.0.10 <12.1 || >=12.1.7 <12.2 || >=12.2.5"
+    "grafanaDependency": ">=11.6.11-0 <12 || >=12.0.10-0 <12.1 || >=12.1.7-0 <12.2 || >=12.2.5-0"
   },
   "queryOptions": {
     "maxDataPoints": true


### PR DESCRIPTION
The Plugins - CD workflow failed with this error 
```
{
    "code": "InvalidArgument",
    "message": "darwin-amd64 zip file: Grafana-owned plugins must use prerelease-inclusive semver ranges. Change \">=9.4.0\" to \">=9.4.0-0\" in grafanaDependency to include prerelease versions.",
    "requestId": "adf67ed0-4179-4328-a0e4-15ab8026a790"
  }
```

This should fix it 