### PR TITLE
Consolidate health check to the backend

### DIFF
--- a/pkg/bigquery/datasource.go
+++ b/pkg/bigquery/datasource.go
@@ -81,6 +81,7 @@ func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 	ds.EnableMultipleConnections = true
 	ds.Interpolator = interpolateMacros
 	ds.CustomRoutes = newResourceHandler(s).Routes()
+	ds.PostCheckHealth = s.checkHealthProjects
 
 	return ds.NewDatasource(ctx, settings)
 }
@@ -420,6 +421,30 @@ func (s *BigQueryDatasource) Projects(ctx context.Context, options ProjectsArgs)
 	}
 
 	return appendAllowlistProjects(projects, bqSettings), nil
+}
+
+// checkHealthProjects verifies that the configured credentials can enumerate
+// GCP projects via the resource manager API. sqlds' generic CheckHealth only
+// exercises the driver's Connect/Ping path (a BigQuery dry-run query), which
+// doesn't touch the resource manager API used to populate the project picker.
+func (s *BigQueryDatasource) checkHealthProjects(ctx context.Context, req *backend.CheckHealthRequest) *backend.CheckHealthResult {
+	if _, err := s.Projects(ctx, ProjectsArgs{}); err != nil {
+		errResp, _ := ut.HandleError(ctx, err, "connecting to resource manager")
+
+		details, marshalErr := json.Marshal(map[string]string{
+			"verboseMessage": err.Error(),
+		})
+		if marshalErr != nil {
+			details = nil
+		}
+
+		return &backend.CheckHealthResult{
+			Status:      backend.HealthStatusError,
+			Message:     errResp.Message,
+			JSONDetails: details,
+		}
+	}
+	return nil
 }
 
 // appendAllowlistProjects adds the projects referenced by the additional

--- a/pkg/bigquery/datasource_test.go
+++ b/pkg/bigquery/datasource_test.go
@@ -201,6 +201,49 @@ func Test_Projects_doesNotPanicWhenResourceManagerServiceMissing(t *testing.T) {
 	})
 }
 
+func Test_checkHealthProjects(t *testing.T) {
+	origPluginConfigFromContext := PluginConfigFromContext
+	defer func() { PluginConfigFromContext = origPluginConfigFromContext }()
+
+	t.Run("returns nil when projects can be listed", func(t *testing.T) {
+		PluginConfigFromContext = func(ctx context.Context) backend.PluginContext {
+			return backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+					ID:       1,
+					UID:      "uid-ok",
+					JSONData: []byte(`{"authenticationType":"jwt","oauthPassThru":true,"defaultProject":"my-project"}`),
+				},
+			}
+		}
+
+		ds := newBigQueryDatasource()
+		result := ds.checkHealthProjects(t.Context(), &backend.CheckHealthRequest{})
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns an error result when projects cannot be listed", func(t *testing.T) {
+		PluginConfigFromContext = func(ctx context.Context) backend.PluginContext {
+			return backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+					ID:  1,
+					UID: "uid-bad",
+					DecryptedSecureJSONData: map[string]string{
+						"privateKey": "randomPrivateKey",
+					},
+					JSONData: []byte(`{"authenticationType":"jwt"}`),
+				},
+			}
+		}
+
+		ds := newBigQueryDatasource()
+		result := ds.checkHealthProjects(t.Context(), &backend.CheckHealthRequest{})
+		require.NotNil(t, result)
+		assert.Equal(t, backend.HealthStatusError, result.Status)
+		assert.NotEmpty(t, result.Message)
+		assert.Contains(t, string(result.JSONDetails), "verboseMessage")
+	})
+}
+
 func Test_appendAllowlistProjects(t *testing.T) {
 	accessible := []*Project{{ProjectId: "myproject", DisplayName: "My project"}}
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,9 +1,8 @@
 import { DataQueryRequest, DataSourceInstanceSettings, ScopedVars, VariableSupportType } from '@grafana/data';
 import { GoogleAuthType } from '@grafana/google-sdk';
 import { EditorMode } from '@grafana/plugin-ui';
-import { DataSourceWithBackend, HealthCheckError, getTemplateSrv } from '@grafana/runtime';
+import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
-import { getApiClient } from 'api';
 
 import { VariableEditor } from './components/VariableEditor';
 import { BigQueryOptions, BigQueryQueryNG, QueryFormat, QueryModel } from './types';
@@ -76,32 +75,6 @@ export class BigQueryDatasource extends DataSourceWithBackend<BigQueryQueryNG, B
     }
 
     return Promise.resolve(importedQueries) as any;
-  }
-
-  async testDatasource() {
-    const health = await this.callHealthCheck();
-    if (health.status?.toLowerCase() === 'error') {
-      return Promise.reject({
-        status: 'error',
-        message: health.message,
-        error: new HealthCheckError(health.message, health.details),
-      });
-    }
-
-    const client = await getApiClient(this.uid);
-    try {
-      await client.getProjects();
-    } catch (err: any) {
-      return Promise.reject({
-        status: 'error',
-        message: err.data?.message || 'Error connecting to resource manager.',
-        error: new HealthCheckError(err.data?.message, err.data?.details),
-      });
-    }
-    return {
-      status: 'OK',
-      message: 'Data source is working',
-    };
   }
 
   applyTemplateVariables(queryModel: BigQueryQueryNG, scopedVars: ScopedVars): QueryModel {


### PR DESCRIPTION
This PR is part 1 of the hackathon to apply similar error categorization from clickhouse into big query.

As a starting point, this PR consolidates the health check to the backend to make sure we keep uniform health check patterns across datasources.

To keep a similar flow to what the frontend used to have, we are leveraging sqlds `PostHealthCheck`