### PR TITLE
Add error categorization to the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.4.0
+
+### Minor Changes
+
+🚀 Move Save & test health checks to the backend and add categorized, actionable errors for authentication, configuration, network, TLS, timeout, and upstream service failures ([#561](https://github.com/grafana/google-bigquery-datasource/pull/561), [#562](https://github.com/grafana/google-bigquery-datasource/pull/562)).
+
+### Patch Changes
+
+⚙️ Chore: migrate the repository from Yarn to npm and update the `@grafana/create-plugin` scaffold ([#558](https://github.com/grafana/google-bigquery-datasource/pull/558), [#560](https://github.com/grafana/google-bigquery-datasource/pull/560)).
+
 ## 3.3.1
 
 ⚙️ Updated dependencies

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -11,6 +11,7 @@
   "words": [
     "BIGNUMERIC",
     "BYTEINT",
+    "clickhouse",
     "cloudresourcemanager",
     "codebases",
     "codecov",
@@ -84,7 +85,8 @@
     "UNIXTIME",
     "uplot",
     "uuidv",
-    "vectorator"
+    "vectorator",
+    "workloadidentitypoolprovider"
   ],
   "language": "en-US"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-bigquery-datasource",
-      "version": "3.3.1",
+      "version": "3.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Google BigQuery datasource for Grafana",
   "license": "Apache-2.0",
   "author": "Grafana Labs <team@grafana.com> (https://grafana.com)",

--- a/pkg/bigquery/datasource.go
+++ b/pkg/bigquery/datasource.go
@@ -31,8 +31,19 @@ import (
 
 var (
 	PluginConfigFromContext = backend.PluginConfigFromContext
-	ErrFailedToConnect      = backend.PluginError(errors.New("Failed to connect"))
 )
+
+// wrapCategorizedConnectionError classifies err and returns a downstream error
+// whose message is prefixed with the category (e.g. "[auth] ...")
+// instead of a generic "failed to connect".
+func wrapCategorizedConnectionError(logger log.Logger, err error) error {
+	if err == nil {
+		return nil
+	}
+	category := ut.CategorizeConnectionError(err)
+	logger.Warn("BigQuery connection failed", "category", string(category))
+	return fmt.Errorf("[%s] %w", category, err)
+}
 
 type BigqueryDatasourceIface interface {
 	sqlds.Driver
@@ -98,12 +109,12 @@ func (s *BigQueryDatasource) Connect(ctx context.Context, config backend.DataSou
 	loggerWithContext := s.logger.FromContext(ctx)
 	settings, err := loadSettings(&config)
 	if err != nil {
-		return nil, err
+		return nil, wrapCategorizedConnectionError(loggerWithContext, err)
 	}
 
 	args, err := parseConnectionArgs(queryArgs)
 	if err != nil {
-		return nil, err
+		return nil, wrapCategorizedConnectionError(loggerWithContext, err)
 	}
 
 	isQueryArgsSet := args != nil
@@ -113,7 +124,7 @@ func (s *BigQueryDatasource) Connect(ctx context.Context, config backend.DataSou
 	if settings.AuthenticationType == "gce" && connectionSettings.Project == "" {
 		defaultProject, err := utils.GCEDefaultProject(context.Background(), BigQueryScope)
 		if err != nil {
-			return nil, errors.WithMessage(err, "Failed to retrieve default GCE project")
+			return nil, wrapCategorizedConnectionError(loggerWithContext, errors.WithMessage(err, "Failed to retrieve default GCE project"))
 		}
 		connectionSettings.Project = defaultProject
 	}
@@ -129,13 +140,13 @@ func (s *BigQueryDatasource) Connect(ctx context.Context, config backend.DataSou
 	if s.getResourceManagerService(config.UID) == nil {
 		err := s.createResourceManagerService(ctx, config, settings, config.UID)
 		if err != nil {
-			return nil, err
+			return nil, wrapCategorizedConnectionError(loggerWithContext, err)
 		}
 	}
 
 	opts, err := config.HTTPClientOptions(ctx)
 	if err != nil {
-		return nil, err
+		return nil, wrapCategorizedConnectionError(loggerWithContext, err)
 	}
 
 	c, exists := s.connections.Load(connectionKey)
@@ -157,15 +168,14 @@ func (s *BigQueryDatasource) Connect(ctx context.Context, config backend.DataSou
 	if exists {
 		dr, db, err := driver.Open(connectionSettings, aC.(*api.API).Client)
 		if err != nil {
-			return nil, ErrFailedToConnect
+			return nil, wrapCategorizedConnectionError(loggerWithContext, err)
 		}
 		s.connections.Store(connectionKey, conn{db: db, driver: dr})
 		return db, nil
 	} else {
 		client, err := newHTTPClient(settings, opts, bigQueryRoute)
 		if err != nil {
-			loggerWithContext.Warn("Failed to get http client options", "error", err)
-			return nil, err
+			return nil, wrapCategorizedConnectionError(loggerWithContext, err)
 		}
 
 		options := []option.ClientOption{option.WithHTTPClient(client)}
@@ -176,20 +186,19 @@ func (s *BigQueryDatasource) Connect(ctx context.Context, config backend.DataSou
 
 		bqClient, err := s.bqFactory(ctx, connectionSettings.Project, options...)
 		if err != nil {
-			loggerWithContext.Warn("Failed to create bigquery client", "error", err)
-			return nil, ErrFailedToConnect
+			return nil, wrapCategorizedConnectionError(loggerWithContext, err)
 		}
 
 		if connectionSettings.EnableStorageAPI {
 			err = bqClient.EnableStorageReadClient(ctx, option.WithTokenSource(ut.JWTConfigFromDataSourceSettings(settings).TokenSource(ctx)))
 			if err != nil {
-				return nil, errors.WithMessage(err, "Failed to enable storage read client")
+				return nil, wrapCategorizedConnectionError(loggerWithContext, errors.WithMessage(err, "Failed to enable storage read client"))
 			}
 		}
 
 		dr, db, err := driver.Open(connectionSettings, bqClient)
 		if err != nil {
-			return nil, ErrFailedToConnect
+			return nil, wrapCategorizedConnectionError(loggerWithContext, err)
 		}
 
 		s.connections.Store(connectionKey, conn{db: db, driver: dr})
@@ -429,7 +438,8 @@ func (s *BigQueryDatasource) Projects(ctx context.Context, options ProjectsArgs)
 // doesn't touch the resource manager API used to populate the project picker.
 func (s *BigQueryDatasource) checkHealthProjects(ctx context.Context, req *backend.CheckHealthRequest) *backend.CheckHealthResult {
 	if _, err := s.Projects(ctx, ProjectsArgs{}); err != nil {
-		errResp, _ := ut.HandleError(ctx, err, "connecting to resource manager")
+		category := ut.CategorizeConnectionError(err)
+		s.logger.FromContext(ctx).Warn("BigQuery resource manager check failed", "category", string(category))
 
 		details, marshalErr := json.Marshal(map[string]string{
 			"verboseMessage": err.Error(),
@@ -440,7 +450,7 @@ func (s *BigQueryDatasource) checkHealthProjects(ctx context.Context, req *backe
 
 		return &backend.CheckHealthResult{
 			Status:      backend.HealthStatusError,
-			Message:     errResp.Message,
+			Message:     fmt.Sprintf("[%s] Error connecting to resource manager: %s", category, err.Error()),
 			JSONDetails: details,
 		}
 	}

--- a/pkg/bigquery/datasource.go
+++ b/pkg/bigquery/datasource.go
@@ -81,6 +81,7 @@ func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 	ds.EnableMultipleConnections = true
 	ds.Interpolator = interpolateMacros
 	ds.CustomRoutes = newResourceHandler(s).Routes()
+	ds.PostCheckHealth = s.checkHealthProjects
 
 	return ds.NewDatasource(ctx, settings)
 }
@@ -420,6 +421,30 @@ func (s *BigQueryDatasource) Projects(ctx context.Context, options ProjectsArgs)
 	}
 
 	return appendAllowlistProjects(projects, bqSettings), nil
+}
+
+// checkHealthProjects verifies that the configured credentials can enumerate
+// GCP projects via the resource manager API. sqlds' generic CheckHealth only
+// exercises the driver's Connect/Ping path (a BigQuery dry-run query), which
+// doesn't touch the resource manager API used to populate the project picker.
+func (s *BigQueryDatasource) checkHealthProjects(ctx context.Context, req *backend.CheckHealthRequest) *backend.CheckHealthResult {
+	if _, err := s.Projects(ctx, ProjectsArgs{}); err != nil {
+		errResp, _ := ut.HandleError(ctx, err, "connecting to resource manager")
+
+		details, marshalErr := json.Marshal(map[string]string{
+			"verboseMessage": err.Error(),
+		})
+		if marshalErr != nil {
+			details = nil
+		}
+
+		return &backend.CheckHealthResult{
+			Status:      backend.HealthStatusError,
+			Message:     errResp.Message,
+			JSONDetails: details,
+		}
+	}
+	return nil
 }
 
 // appendAllowlistProjects adds the projects referenced by the additional

--- a/pkg/bigquery/datasource_test.go
+++ b/pkg/bigquery/datasource_test.go
@@ -201,6 +201,49 @@ func Test_Projects_doesNotPanicWhenResourceManagerServiceMissing(t *testing.T) {
 	})
 }
 
+func Test_checkHealthProjects(t *testing.T) {
+	origPluginConfigFromContext := PluginConfigFromContext
+	defer func() { PluginConfigFromContext = origPluginConfigFromContext }()
+
+	t.Run("returns nil when projects can be listed", func(t *testing.T) {
+		PluginConfigFromContext = func(ctx context.Context) backend.PluginContext {
+			return backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+					ID:       1,
+					UID:      "uid-ok",
+					JSONData: []byte(`{"authenticationType":"jwt","oauthPassThru":true,"defaultProject":"my-project"}`),
+				},
+			}
+		}
+
+		ds := newBigQueryDatasource()
+		result := ds.checkHealthProjects(t.Context(), &backend.CheckHealthRequest{})
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns an error result when projects cannot be listed", func(t *testing.T) {
+		PluginConfigFromContext = func(ctx context.Context) backend.PluginContext {
+			return backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+					ID:  1,
+					UID: "uid-bad",
+					DecryptedSecureJSONData: map[string]string{
+						"privateKey": "randomPrivateKey",
+					},
+					JSONData: []byte(`{"authenticationType":"jwt"}`),
+				},
+			}
+		}
+
+		ds := newBigQueryDatasource()
+		result := ds.checkHealthProjects(t.Context(), &backend.CheckHealthRequest{})
+		require.NotNil(t, result)
+		assert.Equal(t, backend.HealthStatusError, result.Status)
+		assert.NotEmpty(t, result.Message)
+		assert.Contains(t, string(result.JSONDetails), "verboseMessage")
+	})
+}
+
 func Test_appendAllowlistProjects(t *testing.T) {
 	accessible := []*Project{{ProjectId: "myproject", DisplayName: "My project"}}
 

--- a/pkg/bigquery/driver/conn.go
+++ b/pkg/bigquery/driver/conn.go
@@ -214,33 +214,29 @@ func (c *Conn) Ping(ctx context.Context) (err error) {
 	job, err := q.Run(ctx)
 
 	if err != nil {
-		// Unwrap the error to get to the root cause
-		rootErr := err
-		for rootErr != nil {
-			// If the error is a Google API error, we handle it in the HandleError function
-			if _, ok := rootErr.(*googleapi.Error); ok {
-				break
-			}
-			if unwrapped := errors.Unwrap(rootErr); unwrapped != nil {
-				rootErr = unwrapped
-			} else {
-				break
+		// Categorize the error for a consistent, actionable message. Only the
+		// category (not the raw error) is logged server-side: the raw message
+		// can carry project/dataset/service-account identifiers.
+		category := utils.CategorizeConnectionError(err)
+		logger.Warn("BigQuery connection check failed", "category", string(category), "authenticationType", c.cfg.AuthenticationType)
+
+		statusCode := 0
+		gcpMsg := ""
+		if gErr, ok := errors.AsType[*googleapi.Error](err); ok {
+			statusCode = gErr.Code
+			if gErr.Message != "" {
+				gcpMsg = ": " + gErr.Message
 			}
 		}
 
-		_, statusCode := utils.HandleError(ctx, rootErr, fmt.Sprintf("Failed to connect with authentication type: %s", c.cfg.AuthenticationType))
 		isTokenForwarding := c.cfg.AuthenticationType == "forwardOAuthIdentity" ||
 			c.cfg.AuthenticationType == "workloadIdentityFederation"
-		gcpMsg := ""
-		if gErr, ok := rootErr.(*googleapi.Error); ok && gErr.Message != "" {
-			gcpMsg = ": " + gErr.Message
-		}
 		if statusCode == 403 && isTokenForwarding {
-			return backend.DownstreamErrorf("connected to BigQuery but missing permissions to run queries%s. Verify the authenticated principal has bigquery.jobs.create on the project and bigquery.dataViewer on the dataset/table", gcpMsg)
+			return backend.DownstreamErrorf("[%s] connected to BigQuery but missing permissions to run queries%s. Verify the authenticated principal has bigquery.jobs.create on the project and bigquery.dataViewer on the dataset/table", category, gcpMsg)
 		} else if statusCode == 401 && isTokenForwarding {
-			return backend.DownstreamErrorf("unauthorized to connect to BigQuery%s. Verify the identity token is valid and not expired", gcpMsg)
+			return backend.DownstreamErrorf("[%s] unauthorized to connect to BigQuery%s. Verify the identity token is valid and not expired", category, gcpMsg)
 		}
-		return rootErr
+		return fmt.Errorf("[%s] %w", category, err)
 	}
 
 	logger.Info("Successful Ping", "status", job.LastStatus().State)

--- a/pkg/bigquery/utils/connection_error.go
+++ b/pkg/bigquery/utils/connection_error.go
@@ -31,17 +31,16 @@ const (
 	ConnectionErrorCategoryUnknown ConnectionErrorCategory = "unknown"
 )
 
-// configErrorSubstrings match this plugin's own static config-validation
-// messages (settings parsing, auth-type/http-client wiring) that are raised
-// before any request reaches Google, and so have no typed representation to
-// switch on.
+// configErrorSubstrings match this plugin's own static validation messages
+// for problems fixable on the datasource config level —
+// raised before any request reaches Google, so they have no typed
+// representation to switch on.
 var configErrorSubstrings = []string{
 	"does not use a token provider",
 	"requires workloadidentitypoolprovider",
 	"missing authentication details",
 	"could not unmarshal",
 	"failed to retrieve default gce project",
-	"error reading query params",
 	"private key",
 }
 

--- a/pkg/bigquery/utils/connection_error.go
+++ b/pkg/bigquery/utils/connection_error.go
@@ -1,0 +1,152 @@
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net"
+	"strings"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/googleapi"
+)
+
+// ConnectionErrorCategory classifies a BigQuery connection/health-check
+// failure into a small set of user-actionable buckets, independent of the
+// specific Go error type or Google API response shape that produced it.
+type ConnectionErrorCategory string
+
+const (
+	// ConnectionErrorCategoryNone is returned for a nil error: there was no
+	// failure to categorize, as opposed to one categorizeConnectionError
+	// couldn't classify (ConnectionErrorCategoryUnknown).
+	ConnectionErrorCategoryNone    ConnectionErrorCategory = ""
+	ConnectionErrorCategoryAuth    ConnectionErrorCategory = "auth"
+	ConnectionErrorCategoryNetwork ConnectionErrorCategory = "network"
+	ConnectionErrorCategoryTLS     ConnectionErrorCategory = "tls"
+	ConnectionErrorCategoryTimeout ConnectionErrorCategory = "timeout"
+	ConnectionErrorCategoryConfig  ConnectionErrorCategory = "config"
+	ConnectionErrorCategoryServer  ConnectionErrorCategory = "server"
+	ConnectionErrorCategoryUnknown ConnectionErrorCategory = "unknown"
+)
+
+// configErrorSubstrings match this plugin's own static config-validation
+// messages (settings parsing, auth-type/http-client wiring) that are raised
+// before any request reaches Google, and so have no typed representation to
+// switch on.
+var configErrorSubstrings = []string{
+	"does not use a token provider",
+	"requires workloadidentitypoolprovider",
+	"missing authentication details",
+	"could not unmarshal",
+	"failed to retrieve default gce project",
+	"error reading query params",
+	"private key",
+}
+
+// CategorizeConnectionError classifies a BigQuery connection or health-check
+// error. Typed errors (Google API responses, OAuth token errors, TLS/x509, net
+// errors) are checked first; string matching is used only as a fallback,
+// either for the plugin's own static config errors or for errors without a
+// distinguishing type.
+func CategorizeConnectionError(err error) ConnectionErrorCategory {
+	if err == nil {
+		return ConnectionErrorCategoryNone
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return ConnectionErrorCategoryTimeout
+	}
+
+	if googleErr, ok := errors.AsType[*googleapi.Error](err); ok {
+		return categorizeHTTPStatus(googleErr.Code)
+	}
+
+	// Any RFC 6749 token-endpoint error (invalid_grant, invalid_client,
+	// unsupported_grant_type, ...) is an OAuth exchange failure, never a
+	// Grafana datasource config problem: nothing in the datasource config UI
+	// controls the grant type or request shape the plugin sends, so there's
+	// no "config" field for a user to go fix. The one exception is a
+	// transient failure on Google's end (rate-limited/unavailable token
+	// endpoint), which is worth its own category rather than being folded
+	// into "auth".
+	if retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err); ok {
+		if retrieveErr.Response != nil {
+			switch category := categorizeHTTPStatus(retrieveErr.Response.StatusCode); category {
+			case ConnectionErrorCategoryTimeout, ConnectionErrorCategoryServer:
+				return category
+			}
+		}
+		return ConnectionErrorCategoryAuth
+	}
+
+	if _, ok := errors.AsType[*tls.CertificateVerificationError](err); ok {
+		return ConnectionErrorCategoryTLS
+	}
+	if _, ok := errors.AsType[x509.UnknownAuthorityError](err); ok {
+		return ConnectionErrorCategoryTLS
+	}
+	if _, ok := errors.AsType[x509.CertificateInvalidError](err); ok {
+		return ConnectionErrorCategoryTLS
+	}
+	if _, ok := errors.AsType[x509.HostnameError](err); ok {
+		return ConnectionErrorCategoryTLS
+	}
+
+	if opErr, ok := errors.AsType[*net.OpError](err); ok && opErr.Op == "dial" {
+		return ConnectionErrorCategoryNetwork
+	}
+	if _, ok := errors.AsType[*net.DNSError](err); ok {
+		return ConnectionErrorCategoryNetwork
+	}
+
+	errStr := strings.ToLower(err.Error())
+
+	for _, substr := range configErrorSubstrings {
+		if strings.Contains(errStr, substr) {
+			return ConnectionErrorCategoryConfig
+		}
+	}
+
+	// TLS string patterns must come before network patterns: TLS errors are
+	// often wrapped inside a net.OpError with Op "read" rather than "dial".
+	if strings.Contains(errStr, "tls:") || strings.Contains(errStr, "x509:") || strings.Contains(errStr, "certificate") {
+		return ConnectionErrorCategoryTLS
+	}
+	if strings.Contains(errStr, "timeout") || strings.Contains(errStr, "deadline exceeded") {
+		return ConnectionErrorCategoryTimeout
+	}
+	if strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "no such host") ||
+		strings.Contains(errStr, "network is unreachable") ||
+		strings.Contains(errStr, "connection reset by peer") {
+		return ConnectionErrorCategoryNetwork
+	}
+
+	return ConnectionErrorCategoryUnknown
+}
+
+// categorizeHTTPStatus maps an HTTP status code from a Google API response
+// (BigQuery, Cloud Resource Manager, or the OAuth token endpoint) to a
+// category. 429/502/503 land in "server" rather than "network": they signal
+// Google-side throttling/availability issues, not a problem with the path
+// between the plugin and Google.
+func categorizeHTTPStatus(code int) ConnectionErrorCategory {
+	switch {
+	case code == 401 || code == 403:
+		return ConnectionErrorCategoryAuth
+	case code == 408 || code == 504:
+		return ConnectionErrorCategoryTimeout
+	case code == 429 || code == 502 || code == 503:
+		return ConnectionErrorCategoryServer
+	case code == 400 || code == 404 || code == 409:
+		return ConnectionErrorCategoryConfig
+	case code >= 500:
+		return ConnectionErrorCategoryServer
+	case code >= 400:
+		return ConnectionErrorCategoryAuth
+	default:
+		return ConnectionErrorCategoryUnknown
+	}
+}

--- a/pkg/bigquery/utils/connection_error_test.go
+++ b/pkg/bigquery/utils/connection_error_test.go
@@ -114,6 +114,28 @@ func TestCategorizeConnectionError(t *testing.T) {
 			err:      &oauth2.RetrieveError{ErrorCode: "unauthorized_client"},
 			expected: ConnectionErrorCategoryAuth,
 		},
+		{
+			// Nothing in the datasource config UI controls the OAuth grant type
+			// or request shape, so there's no "config" field for a user to fix.
+			name:     "oauth2 invalid_request is an OAuth exchange failure, not a config problem",
+			err:      &oauth2.RetrieveError{ErrorCode: "invalid_request", ErrorDescription: "Missing parameter: grant_type"},
+			expected: ConnectionErrorCategoryAuth,
+		},
+		{
+			name:     "oauth2 unsupported_grant_type is an OAuth exchange failure, not a config problem",
+			err:      &oauth2.RetrieveError{ErrorCode: "unsupported_grant_type"},
+			expected: ConnectionErrorCategoryAuth,
+		},
+		{
+			name:     "oauth2 response status code falls back to auth, not config, when the status is config-shaped",
+			err:      &oauth2.RetrieveError{Response: &http.Response{StatusCode: 404}},
+			expected: ConnectionErrorCategoryAuth,
+		},
+		{
+			name:     "oauth2 response status code still surfaces a transient server failure",
+			err:      &oauth2.RetrieveError{Response: &http.Response{StatusCode: 503}},
+			expected: ConnectionErrorCategoryServer,
+		},
 
 		// --- Config ---
 		{
@@ -124,21 +146,6 @@ func TestCategorizeConnectionError(t *testing.T) {
 		{
 			name:     "googleapi 404",
 			err:      &googleapi.Error{Code: 404, Message: "Not Found"},
-			expected: ConnectionErrorCategoryConfig,
-		},
-		{
-			name:     "oauth2 invalid_request",
-			err:      &oauth2.RetrieveError{ErrorCode: "invalid_request", ErrorDescription: "Missing parameter: grant_type"},
-			expected: ConnectionErrorCategoryConfig,
-		},
-		{
-			name:     "oauth2 unsupported_grant_type",
-			err:      &oauth2.RetrieveError{ErrorCode: "unsupported_grant_type"},
-			expected: ConnectionErrorCategoryConfig,
-		},
-		{
-			name:     "oauth2 response status code used when error code is empty",
-			err:      &oauth2.RetrieveError{Response: &http.Response{StatusCode: 404}},
 			expected: ConnectionErrorCategoryConfig,
 		},
 		{
@@ -164,11 +171,6 @@ func TestCategorizeConnectionError(t *testing.T) {
 		{
 			name:     "failed to retrieve default gce project",
 			err:      fmt.Errorf("Failed to retrieve default GCE project: %w", errors.New("metadata: GCE metadata \"project/project-id\" not defined")),
-			expected: ConnectionErrorCategoryConfig,
-		},
-		{
-			name:     "error reading query params",
-			err:      fmt.Errorf("error reading query params: %s", "unexpected end of JSON input"),
 			expected: ConnectionErrorCategoryConfig,
 		},
 		{
@@ -284,6 +286,11 @@ func TestCategorizeConnectionError(t *testing.T) {
 		{
 			name:     "completely unknown error",
 			err:      errors.New("something went very wrong"),
+			expected: ConnectionErrorCategoryUnknown,
+		},
+		{
+			name:     "error reading query params is not a datasource config problem",
+			err:      fmt.Errorf("error reading query params: %s", "unexpected end of JSON input"),
 			expected: ConnectionErrorCategoryUnknown,
 		},
 	}

--- a/pkg/bigquery/utils/connection_error_test.go
+++ b/pkg/bigquery/utils/connection_error_test.go
@@ -1,0 +1,297 @@
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/googleapi"
+)
+
+func TestCategorizeConnectionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected ConnectionErrorCategory
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: ConnectionErrorCategoryNone,
+		},
+
+		// --- Timeout ---
+		{
+			name:     "context deadline exceeded",
+			err:      context.DeadlineExceeded,
+			expected: ConnectionErrorCategoryTimeout,
+		},
+		{
+			name:     "context canceled",
+			err:      context.Canceled,
+			expected: ConnectionErrorCategoryTimeout,
+		},
+		{
+			name:     "wrapped context deadline exceeded",
+			err:      fmt.Errorf("outer: %w", context.DeadlineExceeded),
+			expected: ConnectionErrorCategoryTimeout,
+		},
+		{
+			name:     "googleapi 408",
+			err:      &googleapi.Error{Code: 408, Message: "Request Timeout"},
+			expected: ConnectionErrorCategoryTimeout,
+		},
+		{
+			name:     "googleapi 504",
+			err:      &googleapi.Error{Code: 504, Message: "Gateway Timeout"},
+			expected: ConnectionErrorCategoryTimeout,
+		},
+		{
+			name:     "timeout in error string",
+			err:      errors.New("read tcp: i/o timeout"),
+			expected: ConnectionErrorCategoryTimeout,
+		},
+		{
+			name:     "deadline exceeded in error string",
+			err:      errors.New("operation timed out: deadline exceeded"),
+			expected: ConnectionErrorCategoryTimeout,
+		},
+
+		// --- Auth ---
+		{
+			name:     "googleapi 401",
+			err:      &googleapi.Error{Code: 401, Message: "Unauthorized"},
+			expected: ConnectionErrorCategoryAuth,
+		},
+		{
+			name:     "googleapi 403",
+			err:      &googleapi.Error{Code: 403, Message: "Permission denied"},
+			expected: ConnectionErrorCategoryAuth,
+		},
+		{
+			name:     "wrapped googleapi 403",
+			err:      fmt.Errorf("ping: %w", &googleapi.Error{Code: 403, Message: "Permission denied"}),
+			expected: ConnectionErrorCategoryAuth,
+		},
+		{
+			// Regression guard: googleapi.Error is checked (by typed .Code) before
+			// the string-based TLS fallback, so a "certificate" mention inside an
+			// auth-failure message can't get shadowed into ConnectionErrorCategoryTLS
+			// the way a clickhouse HTTP-transport string error could.
+			name:     "googleapi 403 mentioning certificate is still auth, not tls",
+			err:      &googleapi.Error{Code: 403, Message: "Invalid authentication: SSL certificate revoked"},
+			expected: ConnectionErrorCategoryAuth,
+		},
+		{
+			name:     "googleapi remaining 4xx falls through to auth",
+			err:      &googleapi.Error{Code: 410, Message: "Gone"},
+			expected: ConnectionErrorCategoryAuth,
+		},
+		{
+			name:     "oauth2 invalid_grant",
+			err:      &oauth2.RetrieveError{ErrorCode: "invalid_grant", ErrorDescription: "Invalid JWT Signature"},
+			expected: ConnectionErrorCategoryAuth,
+		},
+		{
+			name:     "oauth2 access_denied",
+			err:      &oauth2.RetrieveError{ErrorCode: "access_denied"},
+			expected: ConnectionErrorCategoryAuth,
+		},
+		{
+			name:     "oauth2 invalid_client is a rejected identity, not a config problem",
+			err:      &oauth2.RetrieveError{ErrorCode: "invalid_client", ErrorDescription: "The OAuth client was not found."},
+			expected: ConnectionErrorCategoryAuth,
+		},
+		{
+			name:     "oauth2 unauthorized_client is a rejected identity, not a config problem",
+			err:      &oauth2.RetrieveError{ErrorCode: "unauthorized_client"},
+			expected: ConnectionErrorCategoryAuth,
+		},
+
+		// --- Config ---
+		{
+			name:     "googleapi 400",
+			err:      &googleapi.Error{Code: 400, Message: "Bad Request"},
+			expected: ConnectionErrorCategoryConfig,
+		},
+		{
+			name:     "googleapi 404",
+			err:      &googleapi.Error{Code: 404, Message: "Not Found"},
+			expected: ConnectionErrorCategoryConfig,
+		},
+		{
+			name:     "oauth2 invalid_request",
+			err:      &oauth2.RetrieveError{ErrorCode: "invalid_request", ErrorDescription: "Missing parameter: grant_type"},
+			expected: ConnectionErrorCategoryConfig,
+		},
+		{
+			name:     "oauth2 unsupported_grant_type",
+			err:      &oauth2.RetrieveError{ErrorCode: "unsupported_grant_type"},
+			expected: ConnectionErrorCategoryConfig,
+		},
+		{
+			name:     "oauth2 response status code used when error code is empty",
+			err:      &oauth2.RetrieveError{Response: &http.Response{StatusCode: 404}},
+			expected: ConnectionErrorCategoryConfig,
+		},
+		{
+			name:     "does not use a token provider",
+			err:      fmt.Errorf(`auth type "foo" does not use a token provider middleware`),
+			expected: ConnectionErrorCategoryConfig,
+		},
+		{
+			name:     "workload identity pool provider required",
+			err:      errors.New("workloadIdentityFederation requires workloadIdentityPoolProvider to be configured"),
+			expected: ConnectionErrorCategoryConfig,
+		},
+		{
+			name:     "missing authentication details",
+			err:      errors.New("datasource is missing authentication details"),
+			expected: ConnectionErrorCategoryConfig,
+		},
+		{
+			name:     "could not unmarshal settings",
+			err:      fmt.Errorf("could not unmarshal DataSourceInfo json: %w", errors.New("unexpected end of JSON input")),
+			expected: ConnectionErrorCategoryConfig,
+		},
+		{
+			name:     "failed to retrieve default gce project",
+			err:      fmt.Errorf("Failed to retrieve default GCE project: %w", errors.New("metadata: GCE metadata \"project/project-id\" not defined")),
+			expected: ConnectionErrorCategoryConfig,
+		},
+		{
+			name:     "error reading query params",
+			err:      fmt.Errorf("error reading query params: %s", "unexpected end of JSON input"),
+			expected: ConnectionErrorCategoryConfig,
+		},
+		{
+			name:     "malformed private key",
+			err:      errors.New("private key should be a PEM or plain PKCS1 or PKCS8; parse error: asn1: syntax error"),
+			expected: ConnectionErrorCategoryConfig,
+		},
+
+		// --- Server ---
+		{
+			name:     "googleapi 500",
+			err:      &googleapi.Error{Code: 500, Message: "Internal Server Error"},
+			expected: ConnectionErrorCategoryServer,
+		},
+		{
+			name:     "googleapi 429 rate limited",
+			err:      &googleapi.Error{Code: 429, Message: "Too Many Requests"},
+			expected: ConnectionErrorCategoryServer,
+		},
+		{
+			name:     "googleapi 503",
+			err:      &googleapi.Error{Code: 503, Message: "Service Unavailable"},
+			expected: ConnectionErrorCategoryServer,
+		},
+
+		// --- Network ---
+		{
+			name: "net.OpError dial connection refused",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: &net.AddrError{Err: "connection refused"},
+			},
+			expected: ConnectionErrorCategoryNetwork,
+		},
+		{
+			name:     "net.DNSError",
+			err:      &net.DNSError{Err: "no such host", Name: "invalid.example.com"},
+			expected: ConnectionErrorCategoryNetwork,
+		},
+		{
+			name:     "connection refused in string",
+			err:      errors.New("dial tcp: connect: connection refused"),
+			expected: ConnectionErrorCategoryNetwork,
+		},
+		{
+			name:     "no such host in string",
+			err:      errors.New("dial tcp: lookup invalid.example.com: no such host"),
+			expected: ConnectionErrorCategoryNetwork,
+		},
+		{
+			name:     "network is unreachable",
+			err:      errors.New("dial tcp: connect: network is unreachable"),
+			expected: ConnectionErrorCategoryNetwork,
+		},
+		{
+			name:     "connection reset by peer",
+			err:      errors.New("read tcp: connection reset by peer"),
+			expected: ConnectionErrorCategoryNetwork,
+		},
+
+		// --- TLS ---
+		{
+			name: "tls.CertificateVerificationError",
+			err: &tls.CertificateVerificationError{
+				UnverifiedCertificates: []*x509.Certificate{},
+				Err:                    errors.New("certificate signed by unknown authority"),
+			},
+			expected: ConnectionErrorCategoryTLS,
+		},
+		{
+			name:     "x509.UnknownAuthorityError",
+			err:      x509.UnknownAuthorityError{},
+			expected: ConnectionErrorCategoryTLS,
+		},
+		{
+			name: "x509.CertificateInvalidError",
+			err: x509.CertificateInvalidError{
+				Cert:   &x509.Certificate{},
+				Reason: x509.Expired,
+			},
+			expected: ConnectionErrorCategoryTLS,
+		},
+		{
+			name: "x509.HostnameError",
+			err: x509.HostnameError{
+				Certificate: &x509.Certificate{},
+				Host:        "wrong.host.example.com",
+			},
+			expected: ConnectionErrorCategoryTLS,
+		},
+		{
+			name:     "tls: in error string",
+			err:      errors.New("tls: handshake failure"),
+			expected: ConnectionErrorCategoryTLS,
+		},
+		{
+			name:     "x509: in error string",
+			err:      errors.New("x509: certificate has expired or is not yet valid"),
+			expected: ConnectionErrorCategoryTLS,
+		},
+		{
+			name: "net.OpError wrapping TLS error (read op, not dial)",
+			err: &net.OpError{
+				Op:  "read",
+				Net: "tcp",
+				Err: errors.New("tls: certificate signed by unknown authority"),
+			},
+			expected: ConnectionErrorCategoryTLS,
+		},
+
+		// --- Unknown ---
+		{
+			name:     "completely unknown error",
+			err:      errors.New("something went very wrong"),
+			expected: ConnectionErrorCategoryUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CategorizeConnectionError(tt.err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,9 +1,8 @@
 import { DataQueryRequest, DataSourceInstanceSettings, ScopedVars, VariableSupportType } from '@grafana/data';
 import { GoogleAuthType } from '@grafana/google-sdk';
 import { EditorMode } from '@grafana/plugin-ui';
-import { DataSourceWithBackend, HealthCheckError, getTemplateSrv } from '@grafana/runtime';
+import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
-import { getApiClient } from 'api';
 
 import { VariableEditor } from './components/VariableEditor';
 import { BigQueryOptions, BigQueryQueryNG, QueryFormat, QueryModel } from './types';
@@ -76,32 +75,6 @@ export class BigQueryDatasource extends DataSourceWithBackend<BigQueryQueryNG, B
     }
 
     return Promise.resolve(importedQueries) as any;
-  }
-
-  async testDatasource() {
-    const health = await this.callHealthCheck();
-    if (health.status?.toLowerCase() === 'error') {
-      return Promise.reject({
-        status: 'error',
-        message: health.message,
-        error: new HealthCheckError(health.message, health.details),
-      });
-    }
-
-    const client = await getApiClient(this.uid);
-    try {
-      await client.getProjects();
-    } catch (err: any) {
-      return Promise.reject({
-        status: 'error',
-        message: err.data?.message || 'Error connecting to resource manager.',
-        error: new HealthCheckError(err.data?.message, err.data?.details),
-      });
-    }
-    return {
-      status: 'OK',
-      message: 'Data source is working',
-    };
   }
 
   applyTemplateVariables(queryModel: BigQueryQueryNG, scopedVars: ScopedVars): QueryModel {


### PR DESCRIPTION
# Summary

The google SDK already  provides a lot of information in terms of the types of errors that can be returned within its framework. 

Because big query uses sqlds's `CheckHealth`, his PR adds error categorization to the backend `Connect` / `Ping` functions which are called by the SDK, so that users can get get human - friendly actionable error messages on failed health checks..

In addition, to prevent sensitive data leakage, this PR also includes more "PII - conscious" logging by ensuring we only log the category + relevant information instead of full raw errors.

## Detailed summary

Categorization is achieved through the following:

- `ConnectionErrorCategory`: none | auth | network | tls | timeout | config | server | unknown.
- `CategorizeConnectionError(err)` checks typed errors first — *googleapi.Error (by HTTP status), *oauth2.RetrieveError, context.DeadlineExceeded/Canceled, TLS/x509 types, net.OpError/net.DNSError — then falls back to string matching only for this plugin's own static config-validation messages and generic timeout/network/TLS substrings on untyped errors.
- config is scoped strictly to "fixable on the Grafana datasource config page." 
- Typed checks always run before string matching, so a googleapi 403 whose message happens to mention "certificate" still resolves to auth via its `.Code`, not tls .
