### PR TITLE
Fix: pin fast-uri to 3.1.7 to resolve high-severity CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10908,9 +10908,9 @@
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Fixes the 4 fast-uri CVEs flagged in https://github.com/grafana/data-sources/issues/1834 (GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp)
- `fast-uri` **3.1.5 → 3.1.7** via lockfile re-resolution (`ajv@8.20.0` already allows `^3.0.1`); no `package.json` override needed
- Note: the linked issue lists the fix target as `2.4.5`, which appears to be an error in the scanning tool's output — `npm audit` and the GHSA advisories confirm `3.1.6+` is the actual fix

## Test plan
- [x] `npm install` succeeds with node 24 (per `.nvmrc`)
- [x] `npm audit` no longer reports fast-uri as vulnerable
- [x] `npm ls fast-uri` confirms `3.1.7` is resolved everywhere
- [x] `typecheck` and `test:jest` pass