### PR TITLE
Prepare release 3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.1
+
+⚙️ Update backend and frontend dependencies, resolving high-severity CVEs in `google.golang.org/grpc`, `golang.org/x/crypto`, `golang.org/x/mod`, and `fast-uri` ([#541](https://github.com/grafana/google-bigquery-datasource/pull/541), [#546](https://github.com/grafana/google-bigquery-datasource/pull/546), [#565](https://github.com/grafana/google-bigquery-datasource/pull/565)).
+
 ## 3.4.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-bigquery-datasource",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-bigquery-datasource",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Google BigQuery datasource for Grafana",
   "license": "Apache-2.0",
   "author": "Grafana Labs <team@grafana.com> (https://grafana.com)",


### PR DESCRIPTION
## Summary
- Bumps version to 3.4.1 and updates CHANGELOG.md
- Covers the CVE fixes merged in #541, #546, and #565 (grpc, golang.org/x/crypto, golang.org/x/mod, fast-uri — grafana/data-sources#1834)
- Syncs package-lock.json's version field